### PR TITLE
Correcting a bugmaster

### DIFF
--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSFlow.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSFlow.java
@@ -273,9 +273,11 @@ public class FSFlow {
             public void widgetSelected(SelectionEvent arg0) {
                 if (!alice.getN().equals(BigInteger.ZERO)) {
                     if (secretKnown) {
+                        bob.setV(alice.getV());
                         alice.generateR();
                         bob.receiveX(alice.getX());
                     } else {
+                        bob.setV(carol.getV());
                         carol.generateR();
                         bob.receiveX(carol.getX());
                     }


### PR DESCRIPTION
Dear reader.

I found an error in the class "FSFlow": As the FSBob-Object is not told the value of "v", the verification is not right in cases a FSCarol-Object is communicating with the FSBob and FSBob and FSCarol both choose the bit "1".

If you look at "...ui.feigefiatshamir.FFSFlow", you will see in line 272 and 276, that the changes I propose are already implemented in that class.

Best regards,
Mareike Paul
// the author of the classes
