### PR TITLE
Vigenere Breaker: handle unfiltered ciphertexts.

### DIFF
--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/VigenereBreakerGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/VigenereBreakerGui.java
@@ -17,6 +17,8 @@ import org.jcryptool.analysis.vigenere.exceptions.IllegalInputException;
 import org.jcryptool.analysis.vigenere.exceptions.NoContentException;
 import org.jcryptool.analysis.vigenere.interfaces.DataProvider;
 import org.jcryptool.analysis.vigenere.views.VigenereBreakerView;
+import org.jcryptool.core.operations.algorithm.classic.textmodify.Transform;
+import org.jcryptool.core.operations.algorithm.classic.textmodify.TransformData;
 import org.jcryptool.core.logging.utils.LogUtil;
 import org.jcryptool.core.util.fonts.FontService;
 
@@ -50,10 +52,18 @@ public class VigenereBreakerGui extends ContentDelegator {
         }
     }
 
+    private String filterChiffre(String chiff)
+    {
+        TransformData filter = TransformData.fromString("filterBlanks");
+        filter.setUnmodified();
+        filter.setAlphabetTransformationON(true);
+        return Transform.transformText(chiff, filter);
+    }
+
     @Override
     protected void toFriedman(final IEditorReference selection) {
         try {
-            chiffre = DataProvider.getInstance().getEditorContent(selection);
+            chiffre = filterChiffre(DataProvider.getInstance().getEditorContent(selection));
             edtitle = selection.getTitle();
             content.dispose();
             content = new FriedmanGui(this, chiffre, selection);
@@ -92,7 +102,7 @@ public class VigenereBreakerGui extends ContentDelegator {
     protected void toQuick(final IEditorReference selection) {
         try {
             edtitle = selection.getTitle();
-            chiffre = DataProvider.getInstance().getEditorContent(selection);
+            chiffre = filterChiffre(DataProvider.getInstance().getEditorContent(selection));
             content.dispose();
             content = new QuickDecryptGui(this, chiffre, selection);
         } catch (IllegalInputException iiEx) {


### PR DESCRIPTION
Apply alphabet transform to filter out non-alphabet
characters from ciphertext before creating a
FreqAnalysisCalc().

This fixes a problem with the graphs if a ciphertext with commas/periods/blanks is sent to the Vigenere Breaker plugin. The problem can be reproduced by creating a Vigenere Ciphertext with the password BCD. The graph bars are smoothed out. Try to send the same text ciphered with password BBB, then the smoothing will not happen because only one row in the Vigenere Table is being used.

Note. There might still be a bug in the FreqAnalysisCalc class, if an unfiltered ciphertext is sent and passlength is greater than 1.
