### PR TITLE
Minimal Points to Win - Numbershark game - corrected

### DIFF
--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberSharkView.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberSharkView.java
@@ -309,7 +309,7 @@ public class NumberSharkView extends ViewPart {
 		for (int i = 0; i < numberOfFields; i++) {
 			numberField[i] = new Number(i + 1);
 		}
-		int minPtsToWin = numberOfFields * (numberOfFields + 1) / 4;
+		int minPtsToWin = (numberOfFields * (numberOfFields + 1) / 4)+1;
 		requiredScore.setText(String.valueOf(minPtsToWin));
 		sharkScore.setText(ZERO_SCORE);
 		playerScore.setText(ZERO_SCORE);


### PR DESCRIPTION
Hi all,

the calculation of the minimum number of points to win for the numbershark game in line 312 was wrong.
    int minPtsToWin = numberOfFields \* (numberOfFields + 1) / 4;

 +1 must be added to the result.
new calculation: int minPtsToWin = (numberOfFields \* (numberOfFields + 1) / 4)+1

Greetings,
Robin Holtmann
