### PR TITLE
SSL/TLS Handshake Visualization GUI improvements in regard to #117 

### DIFF
--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
@@ -191,6 +191,7 @@ public class SubstitutionAnalysisView extends ViewPart {
 		});
 		return panel;
 	}
+	//hghg
 
 	private void contributeToActionBars() {
 		IActionBars bars = getViewSite().getActionBars();

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
@@ -191,7 +191,6 @@ public class SubstitutionAnalysisView extends ViewPart {
 		});
 		return panel;
 	}
-	//hghg
 
 	private void contributeToActionBars() {
 		IActionBars bars = getViewSite().getActionBars();

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientCertificateComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientCertificateComposite.java
@@ -23,6 +23,8 @@ import javax.crypto.KeyAgreement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -138,25 +140,14 @@ public class ClientCertificateComposite extends Composite implements
 		this.sslView = sslView;
 
 		grpClientCertificate = new Group(this, SWT.NONE);
-		grpClientCertificate.setBounds(0, 0, 326, 175);
-		grpClientCertificate
-				.setText(Messages.ClientCertificateCompositeGrpClientCertificate);
+		grpClientCertificate.setLayout(new GridLayout(6, false));
+		grpClientCertificate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		grpClientCertificate.setText(Messages.ClientCertificateCompositeGrpClientCertificate);
 
 		lblCertificate = new Label(grpClientCertificate, SWT.NONE);
-		lblCertificate.setBounds(10, 25, 160, 15);
-		lblCertificate
-				.setText(Messages.ClientCertificateCompositeLblCertifcate);
-
-		lblClientKeyExchange = new Label(grpClientCertificate, SWT.NONE);
-		lblClientKeyExchange.setBounds(10, 55, 110, 15);
-		lblClientKeyExchange
-				.setText(Messages.ClientCertificateCompositeLblClientKeyExchange);
-
-		lblCertificateVerify = new Label(grpClientCertificate, SWT.NONE);
-		lblCertificateVerify.setBounds(10, 85, 90, 15);
-		lblCertificateVerify
-				.setText(Messages.ClientCertificateCompositeLblCertificateVerify);
-
+		lblCertificate.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false, 4, 1));
+		lblCertificate.setText(Messages.ClientCertificateCompositeLblCertifcate);
+		
 		// Creates a new object from CertificateShow to display the client
 		// certificate
 		btnShow = new Button(grpClientCertificate, SWT.NONE);
@@ -170,12 +161,24 @@ public class ClientCertificateComposite extends Composite implements
 				}
 			}
 		});
-		btnShow.setBounds(241, 20, 75, 25);
+		btnShow.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, false, false, 2, 1));
 		btnShow.setText(Messages.ClientCertificateCompositeBtnShow);
+
+		lblClientKeyExchange = new Label(grpClientCertificate, SWT.NONE);
+		lblClientKeyExchange.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false, 4, 1));
+		lblClientKeyExchange.setText(Messages.ClientCertificateCompositeLblClientKeyExchange);
+
+		lblCertificateVerify = new Label(grpClientCertificate, SWT.NONE);
+		lblCertificateVerify.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false, 4, 2));
+		lblCertificateVerify.setText(Messages.ClientCertificateCompositeLblCertificateVerify);
+		
+		Composite btnComposite = new Composite(grpClientCertificate, SWT.NONE);
+		btnComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 6, 1));
+		btnComposite.setLayout(new GridLayout(2, true));
 
 		// The information button which toggles to the word "Parameter" if
 		// pressed once
-		btnInfo = new Button(grpClientCertificate, SWT.NONE);
+		btnInfo = new Button(btnComposite, SWT.NONE);
 		btnInfo.addMouseListener(new MouseAdapter() {
 			public void mouseUp(MouseEvent e) {
 				infoText = !infoText;
@@ -188,17 +191,17 @@ public class ClientCertificateComposite extends Composite implements
 				refreshInformations();
 			}
 		});
-		btnInfo.setBounds(70, 140, 100, 25);
+		btnInfo.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		btnInfo.setText(Messages.ClientCertificateCompositeBtnInfo);
 
 		// Ends this step and moves on to the next step
-		btnNextStep = new Button(grpClientCertificate, SWT.NONE);
+		btnNextStep = new Button(btnComposite, SWT.NONE);
 		btnNextStep.addMouseListener(new MouseAdapter() {
 			public void mouseUp(MouseEvent e) {
 				sslView.nextStep();
 			}
 		});
-		btnNextStep.setBounds(176, 140, 140, 25);
+		btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		btnNextStep.setText(Messages.ClientCertificateCompositeBtnNextStep);
 	}
 

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientChangeCipherSpecComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientChangeCipherSpecComposite.java
@@ -19,6 +19,8 @@ import javax.crypto.KeyAgreement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -95,13 +97,13 @@ public class ClientChangeCipherSpecComposite extends Composite implements
 		this.sslView = sslView;
 
 		grpClientChangeCipher = new Group(this, SWT.NONE);
-		grpClientChangeCipher.setBounds(0, 0, 326, 175);
-		grpClientChangeCipher
-		.setText(Messages.ClientChangeCipherSpecCompositeLblClientChangeCipher);
+		grpClientChangeCipher.setLayout(new GridLayout(2, false));
+		grpClientChangeCipher.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		grpClientChangeCipher.setText(Messages.ClientChangeCipherSpecCompositeLblClientChangeCipher);
+		
 		lblChangeCipherSpec = new Label(grpClientChangeCipher, SWT.NONE);
-		lblChangeCipherSpec.setBounds(10, 25, 110, 20);
-		lblChangeCipherSpec
-		.setText(Messages.ClientChangeCipherSpecCompositeLblClientChangeCipherSpec);
+		lblChangeCipherSpec.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
+		lblChangeCipherSpec.setText(Messages.ClientChangeCipherSpecCompositeLblClientChangeCipherSpec);
 
 		btnInformationen = new Button(grpClientChangeCipher, SWT.NONE);
 		btnInformationen.addMouseListener(new MouseAdapter() {
@@ -117,10 +119,8 @@ public class ClientChangeCipherSpecComposite extends Composite implements
 
 			}
 		});
-		btnInformationen.setLocation(216, 140);
-		btnInformationen.setSize(100, 25);
-		btnInformationen
-		.setText(Messages.ClientChangeCipherSpecCompositeBtnInformation);
+		btnInformationen.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
+		btnInformationen.setText(Messages.ClientChangeCipherSpecCompositeBtnInformation);
 	}
 
 	/**

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientFinishedComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientFinishedComposite.java
@@ -25,6 +25,8 @@ import javax.crypto.NoSuchPaddingException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -74,12 +76,12 @@ public class ClientFinishedComposite extends Composite implements ProtocolStep {
 		this.sslView = sslView;
 
 		grpClientFinished = new Group(this, SWT.NONE);
-		grpClientFinished.setBounds(0, 0, 326, 175);
-		grpClientFinished
-				.setText(Messages.ClientFinishedCompositeGrpServerFinished);
+		grpClientFinished.setLayout(new GridLayout(2, false));
+		grpClientFinished.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		grpClientFinished.setText(Messages.ClientFinishedCompositeGrpServerFinished);
 
 		lblFinished = new Label(grpClientFinished, SWT.NONE);
-		lblFinished.setBounds(10, 25, 50, 20);
+		lblFinished.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
 		lblFinished.setText(Messages.ClientFinishedCompositeLblFinished);
 
 		btnInformationen = new Button(grpClientFinished, SWT.NONE);
@@ -99,8 +101,7 @@ public class ClientFinishedComposite extends Composite implements ProtocolStep {
 
 			}
 		});
-		btnInformationen.setLocation(216, 140);
-		btnInformationen.setSize(100, 25);
+		btnInformationen.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
 		btnInformationen
 				.setText(Messages.ClientFinishedCompositeBtnInformation);
 	}

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientHelloComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientHelloComposite.java
@@ -19,6 +19,8 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
@@ -70,43 +72,24 @@ public class ClientHelloComposite extends Composite implements ProtocolStep {
 	 * @param sslView
 	 * 			the element who calls, in our case SslView
 	 */
-	public ClientHelloComposite(Composite parent, int style,final SslView sslView) {
+	public ClientHelloComposite(Composite parent, int style, final SslView sslView) {
 		super(parent, style);
 		this.sslView = sslView;
 
 		defineTlsLists();
-
+		
 		Group grpClientHello = new Group(this, SWT.NONE);
 		grpClientHello.setText(Messages.ClientHelloCompositeGrpClientHello);
-		grpClientHello.setBounds(0, 0, 330, 175);
-
-		Label lblCipherSuite = new Label(grpClientHello, SWT.NONE);
-		lblCipherSuite.setLocation(10, 85);
-		lblCipherSuite.setSize(70, 15);
-		lblCipherSuite.setText(Messages.ClientHelloCompositeLblCipherSuit);
-
-		Label lblRandom = new Label(grpClientHello, SWT.NONE);
-		lblRandom.setLocation(10, 55);
-		lblRandom.setSize(55, 15);
-		lblRandom.setText(Messages.ClientHelloCompositeLblRandom);
-
-		Label lblSessionId = new Label(grpClientHello, SWT.NONE);
-		lblSessionId.setLocation(10, 115);
-		lblSessionId.setSize(70, 15);
-		lblSessionId.setText(Messages.ClientHelloCompositeLblSessionId);
-
-		Label lblSessionIdValue = new Label(grpClientHello, SWT.NONE);
-		lblSessionIdValue.setLocation(90, 115);
-		lblSessionIdValue.setSize(75, 15);
-		lblSessionIdValue.setText("0");
-
-		Label lblVersion = new Label(grpClientHello, SWT.NONE);
-		lblVersion.setLocation(10, 25);
-		lblVersion.setSize(55, 15);
-		lblVersion.setText(Messages.ClientHelloCompositeLblVersion);
+		grpClientHello.setLayout(new GridLayout(6, false));
+		grpClientHello.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
 		
-
+		//Version
+		Label lblVersion = new Label(grpClientHello, SWT.NONE);
+		lblVersion.setText(Messages.ClientHelloCompositeLblVersion);
+		lblVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		
 		cmdVersion = new Combo(grpClientHello, SWT.NONE);
+		cmdVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 5, 1));
 		cmdVersion.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -128,13 +111,34 @@ public class ClientHelloComposite extends Composite implements ProtocolStep {
 				refreshInformations();
 			}
 		});
-		cmdVersion.setLocation(90, 22);
-		cmdVersion.setSize(90, 23);
 		cmdVersion.add(Messages.Tls0);
 		cmdVersion.add(Messages.Tls1);
 		cmdVersion.add(Messages.Tls2);
 		cmdVersion.select(2);
 
+		//Random
+		Label lblRandom = new Label(grpClientHello, SWT.NONE);
+		lblRandom.setText(Messages.ClientHelloCompositeLblRandom);
+		lblRandom.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		
+		txtRandom = new Text(grpClientHello, SWT.BORDER);
+		txtRandom.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		
+		btnGenerate = new Button(grpClientHello, SWT.NONE);
+		btnGenerate.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseUp(MouseEvent e) {
+				createRandom();
+			}
+		});
+		btnGenerate.setText(Messages.ClientHelloCompositeBtnGenerate);
+		btnGenerate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+
+		//Cipher
+		Label lblCipherSuite = new Label(grpClientHello, SWT.NONE);
+		lblCipherSuite.setText(Messages.ClientHelloCompositeLblCipherSuit);
+		lblCipherSuite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		
 		cmdCipher = new Combo(grpClientHello, SWT.NONE);
 		cmdCipher.addSelectionListener(new SelectionAdapter() {
 			@Override
@@ -179,15 +183,27 @@ public class ClientHelloComposite extends Composite implements ProtocolStep {
 			}
 		});
 
-		cmdCipher.setLocation(90, 82);
-		cmdCipher.setSize(160, 23);
+		cmdCipher.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 5, 1));
 		for (int i = 0; i < tls2.size(); i++) {
 			cmdCipher.add(tls2.get(i));
 		}
 		cmdCipher.select(33);
 
+		//SessionId
+		Label lblSessionId = new Label(grpClientHello, SWT.NONE);
+		lblSessionId.setText(Messages.ClientHelloCompositeLblSessionId);
+		lblSessionId.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 
-		btnInformation = new Button(grpClientHello, SWT.NONE);
+		Label lblSessionIdValue = new Label(grpClientHello, SWT.NONE);
+		lblSessionIdValue.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 5, 1));
+		lblSessionIdValue.setText("0");
+
+		//Buttons
+		Composite btnComposite = new Composite(grpClientHello, SWT.NONE);
+		btnComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 6, 1));
+		btnComposite.setLayout(new GridLayout(2, true));
+		
+		btnInformation = new Button(btnComposite, SWT.NONE);
 		btnInformation.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseUp(MouseEvent e) {
@@ -200,26 +216,10 @@ public class ClientHelloComposite extends Composite implements ProtocolStep {
 				refreshInformations();
 			}
 		});
-		btnInformation.setLocation(65, 140);
-		btnInformation.setSize(100, 25);
 		btnInformation.setText(Messages.ClientHelloCompositeBtnInformation);
+		btnInformation.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 
-		btnGenerate = new Button(grpClientHello, SWT.NONE);
-		btnGenerate.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseUp(MouseEvent e) {
-				createRandom();
-			}
-		});
-		btnGenerate.setLocation(240, 50);
-		btnGenerate.setSize(75, 25);
-		btnGenerate.setText(Messages.ClientHelloCompositeBtnGenerate);
-
-		txtRandom = new Text(grpClientHello, SWT.BORDER);
-		txtRandom.setLocation(90, 52);
-		txtRandom.setSize(140, 23);
-
-		btnNextStep = new Button(grpClientHello, SWT.NONE);
+		btnNextStep = new Button(btnComposite, SWT.NONE);
 		btnNextStep.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseUp(MouseEvent e) {
@@ -227,7 +227,7 @@ public class ClientHelloComposite extends Composite implements ProtocolStep {
 			}
 		});
 		btnNextStep.setText(Messages.ClientHelloCompositeBtnNextStep);
-		btnNextStep.setBounds(175, 140, 140, 25);
+		btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 
 		tls2CipherSuites.add(cmdCipher.getItem(cmdCipher.getSelectionIndex()));
 		tls2CipherSuitesHex.add(tls2Hex.get(cmdCipher.getSelectionIndex()));

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerCertificateComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerCertificateComposite.java
@@ -21,6 +21,8 @@ import javax.crypto.KeyAgreement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -152,28 +154,41 @@ public class ServerCertificateComposite extends Composite implements
 		this.sslView = sslView;
 
 		grpServerCertificate = new Group(this, SWT.NONE);
-		grpServerCertificate.setBounds(10, 0, 326, 175);
-		grpServerCertificate
-				.setText(Messages.ServerCertificateCompositeServerCertificate);
+		grpServerCertificate.setLayout(new GridLayout(6, false));
+		grpServerCertificate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		grpServerCertificate.setText(Messages.ServerCertificateCompositeServerCertificate);
+		
+		lblCertificate = new Label(grpServerCertificate, SWT.NONE);
+		lblCertificate.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false, 4, 1));
+		lblCertificate.setText(Messages.ServerCertificateCompositeLblCertificate);
+		
+		// Creates a new Object from CertificateShow and displays the
+		// ServerCertificate
+		btnShow = new Button(grpServerCertificate, SWT.NONE);
+		btnShow.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, false, false, 2, 1));
+		btnShow.addMouseListener(new MouseAdapter() {
+			public void mouseUp(MouseEvent e) {
+				try {
+					CertificateShow cShow = new CertificateShow(certServer,
+							exchKey.getPublic());
+				} catch (IllegalStateException e1) {
+
+				}
+			}
+		});
+		btnShow.setText(Messages.ServerCertificateCompositeBtnShow);
 
 		lblServerKeyExchange = new Label(grpServerCertificate, SWT.NONE);
-		lblServerKeyExchange.setBounds(10, 55, 140, 15);
-		lblServerKeyExchange
-				.setText(Messages.ServerCertificateCompositeLblServerKeyExchange);
+		lblServerKeyExchange.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 6, 1));
+		lblServerKeyExchange.setText(Messages.ServerCertificateCompositeLblServerKeyExchange);
 
 		lblCertificateRequest = new Label(grpServerCertificate, SWT.NONE);
-		lblCertificateRequest.setBounds(10, 85, 173, 15);
-		lblCertificateRequest
-				.setText(Messages.ServerCertificateCompositeLblCertificateRequest);
-
-		lblServerHelloDone = new Label(grpServerCertificate, SWT.NONE);
-		lblServerHelloDone.setBounds(10, 115, 100, 15);
-		lblServerHelloDone
-				.setText(Messages.ServerCertificateCompositeLblServerHelloDone);
+		lblCertificateRequest.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1));
+		lblCertificateRequest.setText(Messages.ServerCertificateCompositeLblCertificateRequest);
 
 		// Adds the Radio Buttons and toggles them. No is default setting.
 		rdbYes = new Button(grpServerCertificate, SWT.RADIO);
-		rdbYes.setBounds(196, 85, 50, 15);
+		rdbYes.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 		rdbYes.addMouseListener(new MouseAdapter() {
 			public void mouseUp(MouseEvent e) {
 				blnCertificateRequest = true;
@@ -182,7 +197,7 @@ public class ServerCertificateComposite extends Composite implements
 		rdbYes.setText(Messages.ServerCertificateCompositeRdbYes);
 
 		rdbNo = new Button(grpServerCertificate, SWT.RADIO);
-		rdbNo.setBounds(256, 85, 60, 15);
+		rdbNo.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 		rdbNo.setSelection(true);
 		rdbNo.addMouseListener(new MouseAdapter() {
 			public void mouseUp(MouseEvent e) {
@@ -190,10 +205,23 @@ public class ServerCertificateComposite extends Composite implements
 			}
 		});
 		rdbNo.setText(Messages.ServerCertificateCompositeRdbNo);
+		
+		lblServerHelloDone = new Label(grpServerCertificate, SWT.NONE);
+		lblServerHelloDone.setBounds(10, 115, 100, 15);
+		lblServerHelloDone.setText(Messages.ServerCertificateCompositeLblServerHelloDone);
+		new Label(grpServerCertificate, SWT.NONE);
+		new Label(grpServerCertificate, SWT.NONE);
+		new Label(grpServerCertificate, SWT.NONE);
+		new Label(grpServerCertificate, SWT.NONE);
+		new Label(grpServerCertificate, SWT.NONE);
+		
+		Composite btnComposite = new Composite(grpServerCertificate, SWT.NONE);
+		btnComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 6, 1));
+		btnComposite.setLayout(new GridLayout(2, true));
 
 		// Toggles the Text in the Information Box. Text is switch to
 		// "Parameter" if used once.
-		btnInfo = new Button(grpServerCertificate, SWT.NONE);
+		btnInfo = new Button(btnComposite, SWT.NONE);
 		btnInfo.addMouseListener(new MouseAdapter() {
 			public void mouseUp(MouseEvent e) {
 				infoText = !infoText;
@@ -206,40 +234,23 @@ public class ServerCertificateComposite extends Composite implements
 				refreshInformations();
 			}
 		});
-		btnInfo.setBounds(70, 140, 100, 25);
+		btnInfo.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		btnInfo.setText(Messages.ServerCertificateCompositeBtnInfo);
 
 		// Ends this step and moves on to the next
-		btnNextStep = new Button(grpServerCertificate, SWT.NONE);
+		btnNextStep = new Button(btnComposite, SWT.NONE);
 		btnNextStep.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseUp(MouseEvent e) {
 				sslView.nextStep();
 			}
 		});
-		btnNextStep.setBounds(176, 140, 140, 25);
+		btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		btnNextStep.setText(Messages.ServerCertificateCompositeBtnNextStep);
 
-		lblCertificate = new Label(grpServerCertificate, SWT.NONE);
-		lblCertificate.setBounds(10, 25, 160, 15);
-		lblCertificate
-				.setText(Messages.ServerCertificateCompositeLblCertificate);
 
-		// Creates a new Object from CertificateShow and displays the
-		// ServerCertificate
-		btnShow = new Button(grpServerCertificate, SWT.NONE);
-		btnShow.setBounds(241, 20, 75, 25);
-		btnShow.addMouseListener(new MouseAdapter() {
-			public void mouseUp(MouseEvent e) {
-				try {
-					CertificateShow cShow = new CertificateShow(certServer,
-							exchKey.getPublic());
-				} catch (IllegalStateException e1) {
 
-				}
-			}
-		});
-		btnShow.setText(Messages.ServerCertificateCompositeBtnShow);
+
 	}
 
 	/**

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerChangeCipherSpecComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerChangeCipherSpecComposite.java
@@ -19,6 +19,8 @@ import javax.crypto.KeyAgreement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -104,14 +106,13 @@ public class ServerChangeCipherSpecComposite extends Composite implements
 		this.sslView = sslView;
 
 		grpServerChangeCipher = new Group(this, SWT.NONE);
-		grpServerChangeCipher.setBounds(0, 0, 326, 175);
-		grpServerChangeCipher
-				.setText(Messages.ServerChangeCipherSpecCompositeLblServerChangeCipher);
+		grpServerChangeCipher.setLayout(new GridLayout(2, false));
+		grpServerChangeCipher.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		grpServerChangeCipher.setText(Messages.ServerChangeCipherSpecCompositeLblServerChangeCipher);
 
 		lblChangeCipherSpec = new Label(grpServerChangeCipher, SWT.NONE);
-		lblChangeCipherSpec.setBounds(10, 25, 110, 20);
-		lblChangeCipherSpec
-				.setText(Messages.ServerChangeCipherSpecCompositeLblServerChangeCipherSpec);
+		lblChangeCipherSpec.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
+		lblChangeCipherSpec.setText(Messages.ServerChangeCipherSpecCompositeLblServerChangeCipherSpec);
 
 		btnInformation = new Button(grpServerChangeCipher, SWT.NONE);
 		btnInformation.addMouseListener(new MouseAdapter() {
@@ -126,10 +127,8 @@ public class ServerChangeCipherSpecComposite extends Composite implements
 				refreshInformations();
 			}
 		});
-		btnInformation.setLocation(70, 140);
-		btnInformation.setSize(100, 25);
-		btnInformation
-				.setText(Messages.ServerChangeCipherSpecCompositeBtnInformation);
+		btnInformation.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
+		btnInformation.setText(Messages.ServerChangeCipherSpecCompositeBtnInformation);
 
 		btnNextStep = new Button(grpServerChangeCipher, SWT.NONE);
 		btnNextStep.addMouseListener(new MouseAdapter() {
@@ -138,9 +137,8 @@ public class ServerChangeCipherSpecComposite extends Composite implements
 				sslView.nextStep();
 			}
 		});
-		btnNextStep.setBounds(176, 140, 140, 25);
-		btnNextStep
-				.setText(Messages.ServerChangeCipherSpecCompositeBtnNextStep);
+		btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
+		btnNextStep.setText(Messages.ServerChangeCipherSpecCompositeBtnNextStep);
 	}
 
 	/**

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerFinishedComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerFinishedComposite.java
@@ -25,6 +25,8 @@ import javax.crypto.NoSuchPaddingException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -74,12 +76,13 @@ public class ServerFinishedComposite extends Composite implements ProtocolStep {
 		this.sslView = sslView;
 
 		grpServerFinished = new Group(this, SWT.NONE);
-		grpServerFinished.setBounds(0, 0, 326, 175);
+		grpServerFinished.setLayout(new GridLayout(2, false));
+		grpServerFinished.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
 		grpServerFinished
 				.setText(Messages.ServerFinishedCompositeGrpServerFinished);
 
 		lblFinished = new Label(grpServerFinished, SWT.NONE);
-		lblFinished.setBounds(10, 25, 50, 20);
+		lblFinished.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
 		lblFinished.setText(Messages.ServerFinishedCompositeLblFinished);
 
 		btnInformation = new Button(grpServerFinished, SWT.NONE);
@@ -97,8 +100,7 @@ public class ServerFinishedComposite extends Composite implements ProtocolStep {
 				refreshInformations();
 			}
 		});
-		btnInformation.setLocation(216, 140);
-		btnInformation.setSize(100, 25);
+		btnInformation.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
 		btnInformation.setText(Messages.ServerFinishedCompositeBtnInformation);
 	}
 

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerHelloComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerHelloComposite.java
@@ -19,6 +19,8 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
@@ -71,68 +73,22 @@ public class ServerHelloComposite extends Composite implements ProtocolStep {
 	 * @param sslView
 	 * 			the element who calls, in our case SslView
 	 */
-	public ServerHelloComposite(Composite parent, int style,
-			final SslView sslView) {
+	public ServerHelloComposite(Composite parent, int style, final SslView sslView) {
 		super(parent, style);
 		this.sslView = sslView;
 		
 		defineTlsLists();
 		
 		grpServerHello = new Group(this, SWT.NONE);
-		grpServerHello.setBounds(0, 0, 326, 175);
+		grpServerHello.setLayout(new GridLayout(6, false));
+		grpServerHello.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
 		grpServerHello.setText(Messages.ServerHelloCompositeGrpServerHello);
 		
-		btnInfo = new Button(grpServerHello, SWT.NONE);
-		btnInfo.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseUp(MouseEvent e) {
-				infoText = !infoText;
-				if(btnInfo.getText().equals(Messages.btnInformationToggleParams)){
-					btnInfo.setText(Messages.ClientCertificateCompositeBtnInfo);
-				}else{
-					btnInfo.setText(Messages.btnInformationToggleParams);
-				}
-				refreshInformations();
-			}
-		});
-		btnInfo.setBounds(65, 140, 100, 25);
-		btnInfo.setText(Messages.ServerHelloCompositeBtnInfo);
-		
+		//Version
 		lblVersion = new Label(grpServerHello, SWT.NONE);
-		lblVersion.setBounds(10, 25, 55, 15);
+		lblVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
 		lblVersion.setText(Messages.ServerHelloCompositeLblVersion);
-
-		lblRandom = new Label(grpServerHello, SWT.NONE);
-		lblRandom.setBounds(10, 55, 55, 15);
-		lblRandom.setText(Messages.ServerHelloCompositeLblRandom);
-
-		lblCipherSuite = new Label(grpServerHello, SWT.NONE);
-		lblCipherSuite.setBounds(10, 85, 70, 15);
-		lblCipherSuite.setText(Messages.ServerHelloCompositeLblCipherSuite);
-
-		lblSessionID = new Label(grpServerHello, SWT.NONE);
-		lblSessionID.setBounds(10, 115, 55, 15);
-		lblSessionID.setText(Messages.ServerHelloCompositeLblSessionID);
-
-		txtRandom = new Text(grpServerHello, SWT.BORDER);
-		txtRandom.setBounds(90, 52, 140, 23);
-
-		cmbCipherSuite = new Combo(grpServerHello, SWT.NONE);
-		cmbCipherSuite.setBounds(90, 82, 160, 23);
 		
-		txtSessionID = new Text(grpServerHello, SWT.BORDER);
-		txtSessionID.setBounds(90, 112, 75, 23);
-
-		btnGenerate = new Button(grpServerHello, SWT.NONE);
-		btnGenerate.addMouseListener(new MouseAdapter() {
-			@Override
-			public void mouseUp(MouseEvent e) {
-				createRandom();
-			}
-		});
-		btnGenerate.setBounds(240, 50, 75, 25);
-		btnGenerate.setText(Messages.ServerHelloCompositeBtnGenerate);
-
 		cmbVersion = new Combo(grpServerHello, SWT.NONE);
 		cmbVersion.addSelectionListener(new SelectionAdapter() {
 			@Override
@@ -154,22 +110,76 @@ public class ServerHelloComposite extends Composite implements ProtocolStep {
 				cmbCipherSuite.select(0);
 			}
 		});
-		cmbVersion.setBounds(90, 22, 90, 20);
+		cmbVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 5, 1));
 		cmbVersion.add(Messages.Tls0);
 		cmbVersion.add(Messages.Tls1);
 		cmbVersion.add(Messages.Tls2);
 		cmbVersion.select(2);
+		
+		//Random 
+		lblRandom = new Label(grpServerHello, SWT.NONE);
+		lblRandom.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		lblRandom.setText(Messages.ServerHelloCompositeLblRandom);
+		
+		txtRandom = new Text(grpServerHello, SWT.BORDER);
+		txtRandom.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+		
+		btnGenerate = new Button(grpServerHello, SWT.NONE);
+		btnGenerate.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseUp(MouseEvent e) {
+				createRandom();
+			}
+		});
+		btnGenerate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+		btnGenerate.setText(Messages.ServerHelloCompositeBtnGenerate);
+		
+		//Cipher
+		lblCipherSuite = new Label(grpServerHello, SWT.NONE);
+		lblCipherSuite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		lblCipherSuite.setText(Messages.ServerHelloCompositeLblCipherSuite);
+		
+		cmbCipherSuite = new Combo(grpServerHello, SWT.NONE);
+		cmbCipherSuite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 5, 1));
+		
+		//SessionId
+		lblSessionID = new Label(grpServerHello, SWT.NONE);
+		lblSessionID.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+		lblSessionID.setText(Messages.ServerHelloCompositeLblSessionID);
+		
+		txtSessionID = new Text(grpServerHello, SWT.BORDER);
+		txtSessionID.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+		
+		//Buttons
+		Composite btnComposite = new Composite(grpServerHello, SWT.NONE);
+		btnComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 6, 1));
+		btnComposite.setLayout(new GridLayout(2, true));
+		
+		btnInfo = new Button(btnComposite, SWT.NONE);
+		btnInfo.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseUp(MouseEvent e) {
+				infoText = !infoText;
+				if(btnInfo.getText().equals(Messages.btnInformationToggleParams)){
+					btnInfo.setText(Messages.ClientCertificateCompositeBtnInfo);
+				}else{
+					btnInfo.setText(Messages.btnInformationToggleParams);
+				}
+				refreshInformations();
+			}
+		});
+		btnInfo.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
+		btnInfo.setText(Messages.ServerHelloCompositeBtnInfo);
 
-		btnNextStep = new Button(grpServerHello, SWT.NONE);
+		btnNextStep = new Button(btnComposite, SWT.NONE);
 		btnNextStep.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseUp(MouseEvent e) {
 				sslView.nextStep();
 			}
 		});
-		btnNextStep.setBounds(175, 140, 140, 25);
+		btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		btnNextStep.setText(Messages.ServerHelloCompositeBtnNextStep);
-		
 	}
 
 	/**

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
@@ -15,8 +15,10 @@ import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -51,6 +53,7 @@ public class SslView extends ViewPart {
     private Button btnPreviousStep;
 
     public static final String ID = "org.jcryptool.visual.ssl.views.SslView"; //$NON-NLS-1$
+	private Group grp_stxInfo;
 
     public SslView() {
     }
@@ -67,8 +70,7 @@ public class SslView extends ViewPart {
         scrolledComposite.setContent(mainContent);
         scrolledComposite.setExpandHorizontal(true);
         scrolledComposite.setExpandVertical(true);
-        scrolledComposite.setMinSize(mainContent.computeSize(1100, 900));
-
+        
         GridLayout gl = new GridLayout(1, false);
         gl.verticalSpacing = 0;
         mainContent.setLayout(gl);
@@ -79,12 +81,14 @@ public class SslView extends ViewPart {
         headline.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 1, 1));
 
         content = new Composite(mainContent, SWT.NONE);
-        content.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
+        content.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
         content.setLayout(new GridLayout(4, false));
-
-        createButtons();
+        
         createGui();
-
+        createButtons();
+       
+        scrolledComposite.setMinSize(mainContent.computeSize(1100, SWT.DEFAULT));
+        
         // Fuer die Hilfe:
         // PlatformUI.getWorkbench().getHelpSystem().setHelp(parent.getShell(), SslPlugin.PLUGIN_ID
         // + ".sslview");
@@ -96,73 +100,72 @@ public class SslView extends ViewPart {
     private void createGui() {
         // Client Composites
         grp_clientComposites = new Group(content, SWT.NONE);
-        GridData gd_clientComposite = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1);
-        gd_clientComposite.widthHint = 350;
+        GridData gd_clientComposite = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 2);
+        gd_clientComposite.widthHint = 360;
         grp_clientComposites.setLayoutData(gd_clientComposite);
         grp_clientComposites.setLayout(new GridLayout());
         grp_clientComposites.setText(Messages.SslViewLblClient);
 
         clientHelloComposite = new ClientHelloComposite(grp_clientComposites, SWT.NONE, this);
-        clientHelloComposite.setLayout(new GridLayout(3, true));
+        clientHelloComposite.setLayout(new GridLayout(1, true));
         clientHelloComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 
         clientCertificateComposite = new ClientCertificateComposite(grp_clientComposites, SWT.NONE, this);
         clientCertificateComposite.setLayout(new GridLayout(3, true));
-        clientCertificateComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 2));
+        clientCertificateComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         clientCertificateComposite.setVisible(false);
 
         clientChangeCipherSpecComposite = new ClientChangeCipherSpecComposite(grp_clientComposites, SWT.NONE, this);
         clientChangeCipherSpecComposite.setLayout(new GridLayout(3, true));
-        clientChangeCipherSpecComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 3));
+        clientChangeCipherSpecComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         clientChangeCipherSpecComposite.setVisible(false);
 
         clientFinishedComposite = new ClientFinishedComposite(grp_clientComposites, SWT.NONE, this);
         clientFinishedComposite.setLayout(new GridLayout(3, true));
-        clientFinishedComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 4));
+        clientFinishedComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         clientFinishedComposite.setVisible(false);
 
         // Draw Panel
-        GridData gd_drawPanel = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1);
+        GridData gd_drawPanel = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 2);
         gd_drawPanel.widthHint = 100;
-        gd_drawPanel.heightHint = 760;
         arrow = new Arrows(content, SWT.NONE);
         arrow.setLayoutData(gd_drawPanel);
 
         // Server Composites
         grp_serverComposites = new Group(content, SWT.NONE);
-        GridData gd_serverComposite = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 3);
-        gd_serverComposite.widthHint = 350;
+        GridData gd_serverComposite = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 2);
+        gd_serverComposite.widthHint = 360;
         grp_serverComposites.setLayoutData(gd_serverComposite);
         grp_serverComposites.setLayout(new GridLayout());
         grp_serverComposites.setText(Messages.SslViewLblServer);
 
         serverHelloComposite = new ServerHelloComposite(grp_serverComposites, SWT.NONE, this);
-        serverHelloComposite.setLayout(new GridLayout(3, true));
+        serverHelloComposite.setLayout(new GridLayout(1, true));
         serverHelloComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         serverHelloComposite.setVisible(false);
 
         serverCertificateComposite = new ServerCertificateComposite(grp_serverComposites, SWT.NONE, this);
         serverCertificateComposite.setLayout(new GridLayout(3, true));
-        serverCertificateComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 2));
+        serverCertificateComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         serverCertificateComposite.setVisible(false);
 
         serverChangeCipherSpecComposite = new ServerChangeCipherSpecComposite(grp_serverComposites, SWT.NONE, this);
         serverChangeCipherSpecComposite.setLayout(new GridLayout(3, true));
-        serverChangeCipherSpecComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 3));
+        serverChangeCipherSpecComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         serverChangeCipherSpecComposite.setVisible(false);
 
         serverFinishedComposite = new ServerFinishedComposite(grp_serverComposites, SWT.NONE, this);
         serverFinishedComposite.setLayout(new GridLayout(3, true));
-        serverFinishedComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 4));
+        serverFinishedComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         serverFinishedComposite.setVisible(false);
 
-        // Information Panel
-        Group grp_stxInfo = new Group(content, SWT.NONE);
-        grp_stxInfo.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 4));
+        //Information Panel
+        grp_stxInfo = new Group(content, SWT.NONE);
+        grp_stxInfo.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, true, true, 1, 1));
         grp_stxInfo.setLayout(new GridLayout());
         grp_stxInfo.setText(Messages.SslViewLblInfo);
 
-        stxInformation = new StyledText(grp_stxInfo, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP);
+        stxInformation = new StyledText(grp_stxInfo, SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.WRAP );
         GridData gd_stxInfo = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
         stxInformation.setLayoutData(gd_stxInfo);
         stxInformation.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
@@ -174,9 +177,13 @@ public class SslView extends ViewPart {
      * Creates the Buttons of the GUI
      */
     private void createButtons() {
-        Group grp_buttons = new Group(mainContent, SWT.NONE);
-        grp_buttons.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, false, false, 3, 1));
-        grp_buttons.setLayout(new GridLayout(3, true));
+    	Group grp_buttons = new Group(content, SWT.NONE);
+        grp_buttons.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
+        RowLayout rl_grpButtons = new RowLayout();
+        rl_grpButtons.wrap = true;
+        rl_grpButtons.pack = false;
+        rl_grpButtons.justify = true;
+        grp_buttons.setLayout(rl_grpButtons);
 
         btnPreviousStep = new Button(grp_buttons, SWT.PUSH);
         btnPreviousStep.addMouseListener(new MouseAdapter() {
@@ -186,7 +193,6 @@ public class SslView extends ViewPart {
             }
         });
         btnPreviousStep.setText(Messages.SslViewBtnPreviousStep);
-        btnPreviousStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
         btnPreviousStep.setEnabled(false);
 
         btnNextStep = new Button(grp_buttons, SWT.PUSH);
@@ -197,7 +203,6 @@ public class SslView extends ViewPart {
             }
         });
         btnNextStep.setText(Messages.SslViewBtnNextStep);
-        btnNextStep.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
 
         Button btnReset = new Button(grp_buttons, SWT.PUSH);
         btnReset.addMouseListener(new MouseAdapter() {
@@ -207,7 +212,6 @@ public class SslView extends ViewPart {
             }
         });
         btnReset.setText(Messages.SslViewBtnReset);
-        btnReset.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
     }
 
     /**
@@ -258,12 +262,13 @@ public class SslView extends ViewPart {
     public void nextStep() {
         if (serverHelloComposite.getVisible() == false) {
             if (clientHelloComposite.checkParameters()) {
-                arrow.moveArrowsby(18);
                 serverHelloComposite.startStep();
                 serverHelloComposite.setVisible(true);
                 serverHelloComposite.enableControls();
                 clientHelloComposite.disableControls();
-                arrow.nextArrow(0, 75, 100, 75, 0, 0, 0);
+                Rectangle clientHelloCompositeBounds = clientHelloComposite.getBounds();
+                int arrowStartHeight = clientHelloCompositeBounds.y + clientHelloCompositeBounds.height / 2;
+                arrow.nextArrow(0, arrowStartHeight, 100, arrowStartHeight, 0, 0, 0);
                 btnPreviousStep.setEnabled(true);
             }
         } else if (serverCertificateComposite.getVisible() == false) {
@@ -280,7 +285,9 @@ public class SslView extends ViewPart {
                 clientCertificateComposite.enableControls();
                 serverCertificateComposite.disableControls();
                 clientCertificateComposite.refreshInformations();
-                arrow.nextArrow(100, 275, 0, 275, 0, 0, 0);
+                Rectangle clientCertificateCompositeBounds = clientCertificateComposite.getBounds();
+                int arrowStartHeight = clientCertificateCompositeBounds.y + clientCertificateCompositeBounds.height / 2;
+                arrow.nextArrow(100, arrowStartHeight, 0, arrowStartHeight, 0, 0, 0);
                 if (!Message.getServerCertificateServerCertificateRequest())
                     clientCertificateComposite.btnShow.setEnabled(false);
             }
@@ -294,7 +301,9 @@ public class SslView extends ViewPart {
                 serverFinishedComposite.enableControls();
                 serverChangeCipherSpecComposite.refreshInformations();
                 clientCertificateComposite.disableControls();
-                arrow.nextArrow(0, 325, 100, 450, 0, 0, 0);
+                Rectangle clientCertificateCompositeBounds = clientCertificateComposite.getBounds();
+                int arrowStartHeight = clientCertificateCompositeBounds.y + clientCertificateCompositeBounds.height / 2 + 20;
+                arrow.nextArrow(0, arrowStartHeight, 100, arrowStartHeight + 100, 0, 0, 0);
             }
         } else if (clientChangeCipherSpecComposite.getVisible() == false) {
             if (serverChangeCipherSpecComposite.checkParameters()) {
@@ -308,10 +317,14 @@ public class SslView extends ViewPart {
                 serverChangeCipherSpecComposite.disableControls();
                 serverFinishedComposite.disableControls();
                 btnNextStep.setEnabled(false);
-                arrow.nextArrow(100, 475, 0, 475, 0, 0, 0);
-                arrow.nextArrow(0, 500, 100, 500, 0, 0, 0);
-                arrow.nextArrow(100, 650, 0, 650, 0, 180, 0);
-                arrow.nextArrow(0, 675, 100, 675, 0, 180, 0);
+                Rectangle serverCipherBounds = serverChangeCipherSpecComposite.getBounds();
+                int arrows1StartHeight = serverCipherBounds.y + serverCipherBounds.height / 2 - 10; 
+                arrow.nextArrow(100, arrows1StartHeight - 12, 0, arrows1StartHeight - 12, 0, 0, 0);
+                arrow.nextArrow(0, arrows1StartHeight + 12, 100, arrows1StartHeight + 12, 0, 0, 0);
+                Rectangle serverFinishedBounds = serverFinishedComposite.getBounds();
+                int arrows2StartHeight = serverFinishedBounds.y + serverFinishedBounds.height / 2 - 10; 
+                arrow.nextArrow(100, arrows2StartHeight - 12, 0, arrows2StartHeight - 12, 0, 180, 0);
+                arrow.nextArrow(0, arrows2StartHeight + 12, 100, arrows2StartHeight + 12, 0, 180, 0);
             }
         }
     }

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
@@ -67,7 +67,6 @@ public class SslView extends ViewPart {
     public void createPartControl(final Composite parent) {
         scrolledComposite = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
         mainContent = new Composite(scrolledComposite, SWT.NONE);
-        scrolledComposite.setContent(mainContent);
         scrolledComposite.setExpandHorizontal(true);
         scrolledComposite.setExpandVertical(true);
         
@@ -81,13 +80,17 @@ public class SslView extends ViewPart {
         headline.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 1, 1));
 
         content = new Composite(mainContent, SWT.NONE);
-        content.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+        GridData gd_content = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+        gd_content.widthHint = 1200;
+        gd_content.heightHint = 800;
+        content.setLayoutData(gd_content);
         content.setLayout(new GridLayout(4, false));
         
         createGui();
         createButtons();
-       
-        scrolledComposite.setMinSize(mainContent.computeSize(1100, SWT.DEFAULT));
+        
+        scrolledComposite.setContent(mainContent);
+        scrolledComposite.setMinSize(mainContent.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         
         // Fuer die Hilfe:
         // PlatformUI.getWorkbench().getHelpSystem().setHelp(parent.getShell(), SslPlugin.PLUGIN_ID
@@ -161,12 +164,14 @@ public class SslView extends ViewPart {
 
         //Information Panel
         grp_stxInfo = new Group(content, SWT.NONE);
-        grp_stxInfo.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, true, true, 1, 1));
+        GridData gd_grpStxInfo = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+        grp_stxInfo.setLayoutData(gd_grpStxInfo);
         grp_stxInfo.setLayout(new GridLayout());
         grp_stxInfo.setText(Messages.SslViewLblInfo);
 
         stxInformation = new StyledText(grp_stxInfo, SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.WRAP );
         GridData gd_stxInfo = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+        gd_stxInfo.widthHint = 300;
         stxInformation.setLayoutData(gd_stxInfo);
         stxInformation.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
         stxInformation.setText(Messages.SslViewStxInformation);
@@ -347,8 +352,8 @@ public class SslView extends ViewPart {
         serverCertificateComposite.resetStep();
         serverHelloComposite.setVisible(false);
         serverHelloComposite.resetStep();
-        clientHelloComposite.resetStep();
         clientHelloComposite.enableControls();
+        clientHelloComposite.resetStep();
         arrow.resetArrows();
         stxInformation.setText(Messages.SslViewStxInformation);
         btnNextStep.setEnabled(true);


### PR DESCRIPTION
Solution to  #117. 
Many GUI parts of this plug-in were using the AbsoluteLayout. This caused problems with High-DPI monitors (cropped text etc.). 
I converted a big part of these into the GridLayout and optimized the overall layout a little bit. 
- There is no more cropped text even at High-DPI monitors
- The navigation buttons on the bottom are moved below the information text area, since most of the time there is not much text to display and it was a waste of space. 
- The information text area is responsive to the overall window size and gets a scroll bar below a certain overall window width. 

Before: 
<img width="897" alt="ssl_tls_handshake__before" src="https://user-images.githubusercontent.com/27727377/32004386-f0b245be-b9a1-11e7-95bb-b8218cd8ce8c.PNG">

After: 
<img width="877" alt="ssl_tls_handshake_after" src="https://user-images.githubusercontent.com/27727377/32004387-f0d934b2-b9a1-11e7-8cf4-e6668023e8fe.PNG">
