### PR TITLE
Changed Group Name Description -> Manual in Plug-in AUP

### DIFF
--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/messages.properties
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/messages.properties
@@ -1,6 +1,6 @@
 AndroidUnlockPattern_ButtonCancelText=Reset input
 AndroidUnlockPattern_ButtonSaveText=Save
-AndroidUnlockPattern_GroupHeadingHelp=Description
+AndroidUnlockPattern_GroupHeadingHelp=Manual
 AndroidUnlockPattern_GroupHeadingModes=Operation
 AndroidUnlockPattern_Heading=Graphical Passwords by means of Android Unlock Pattern (AUP)
 AndroidUnlockPattern_HeadingInfoText=This visualization demonstrates the graphical password paradigm, available since 2008 in Android devices.

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/messages_de.properties
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/messages_de.properties
@@ -1,6 +1,6 @@
 AndroidUnlockPattern_ButtonCancelText = Eingabe l\u00F6schen
 AndroidUnlockPattern_ButtonSaveText = Speichern
-AndroidUnlockPattern_GroupHeadingHelp = Erkl\u00E4rungen
+AndroidUnlockPattern_GroupHeadingHelp = Bedienung
 AndroidUnlockPattern_GroupHeadingModes = Operation
 AndroidUnlockPattern_Heading = Grafische Passw\u00F6rter anhand der Android-Mustersperre (AUP)
 AndroidUnlockPattern_HeadingInfoText = Diese Visualisierung veranschaulicht das seit 2008 in Android-Ger\u00E4ten verf\u00FCgbare grafische Passwort-Verfahren.


### PR DESCRIPTION
I have chagend the text of the help box to Manual/Bedienung.
![grafik](https://user-images.githubusercontent.com/20046726/32297521-b55ce4c0-bf4f-11e7-89b5-b2ebfcc0aad0.png)
