### PR TITLE
Grille gui fix

### DIFF
--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -78,15 +78,15 @@ public class DemonstrationPainter implements PaintListener {
             e.gc.setFont(FontService.getLargeFont());
             e.gc.drawText(Messages.getString("DemonstrationPainter.description"), 0, 0); //$NON-NLS-1$
             if (!demonstration.padding.equals("")) { //$NON-NLS-1$
-                e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 80); //$NON-NLS-1$
+                e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 140); //$NON-NLS-1$
                 Color savedColor = e.gc.getForeground();
                 e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-                e.gc.drawString(demonstration.padding.substring(0, Math.min(25, demonstration.padding.length())), 95,
-                        80);
-                for (int i = 25; i < demonstration.padding.length(); i = i + 40)
-                    e.gc.drawString(
-                            demonstration.padding.substring(i, Math.min(demonstration.padding.length(), i + 40)), 0,
-                            95 + (i / 25) * 20);
+                String padding = "";
+                for (int i = 0; i < demonstration.padding.length(); i = i + 35) {
+                	padding += demonstration.padding.substring(i, Math.min(demonstration.padding.length(), i+35));
+                	padding += "\n";
+                }
+                e.gc.drawText(padding, 0, 175);
                 e.gc.setForeground(savedColor);
 
             }

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -79,7 +79,7 @@ public class DemonstrationPainter implements PaintListener {
 			e.gc.drawText(Messages.getString("DemonstrationPainter.description"), 0, 0); //$NON-NLS-1$
 			if (!demonstration.padding.equals("")) { //$NON-NLS-1$
 				e.gc.drawText(Messages.getString("DemonstrationPainter.padding") + " (" + demonstration.padding.length() //$NON-NLS-1$
-						+ ")", 0, 140);
+						+ "):", 0, 140);
 				Color savedColor = e.gc.getForeground();
 				e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
 				String padding = "";

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -64,33 +64,34 @@ public class DemonstrationPainter implements PaintListener {
         }
     }
 
-    public void paintControl(PaintEvent e) {
-        width = parent.getSize().x;
-        height = parent.getSize().y;
-        if (width > height) {
-        	width = height;
-        } else {
-        	height = width;
-        }
-        if (demonstration.getCurrentStep() == 0) {
-            e.gc.fillRectangle(0, 0, width, height);
-        } else if (demonstration.getCurrentStep() == 1) {
-            e.gc.setFont(FontService.getLargeFont());
-            e.gc.drawText(Messages.getString("DemonstrationPainter.description"), 0, 0); //$NON-NLS-1$
-            if (!demonstration.padding.equals("")) { //$NON-NLS-1$
-                e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 140); //$NON-NLS-1$
-                Color savedColor = e.gc.getForeground();
-                e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-                String padding = "";
-                for (int i = 0; i < demonstration.padding.length(); i = i + 35) {
-                	padding += demonstration.padding.substring(i, Math.min(demonstration.padding.length(), i+35));
-                	padding += "\n";
-                }
-                e.gc.drawText(padding, 0, 175);
-                e.gc.setForeground(savedColor);
+	public void paintControl(PaintEvent e) {
+		width = parent.getSize().x;
+		height = parent.getSize().y;
+		if (width > height) {
+			width = height;
+		} else {
+			height = width;
+		}
+		if (demonstration.getCurrentStep() == 0) {
+			e.gc.fillRectangle(0, 0, width, height);
+		} else if (demonstration.getCurrentStep() == 1) {
+			e.gc.setFont(FontService.getLargeFont());
+			e.gc.drawText(Messages.getString("DemonstrationPainter.description"), 0, 0); //$NON-NLS-1$
+			if (!demonstration.padding.equals("")) { //$NON-NLS-1$
+				e.gc.drawText(Messages.getString("DemonstrationPainter.padding") + " (" + demonstration.padding.length() //$NON-NLS-1$
+						+ ")", 0, 140);
+				Color savedColor = e.gc.getForeground();
+				e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
+				String padding = "";
+				for (int i = 0; i < demonstration.padding.length(); i = i + 35) {
+					padding += demonstration.padding.substring(i, Math.min(demonstration.padding.length(), i + 35));
+					padding += "\n";
+				}
+				e.gc.drawText(padding, 0, 175);
+				e.gc.setForeground(savedColor);
 
-            }
-        } else if (demonstration.getCurrentStep() <= 5) {
+			}
+		} else if (demonstration.getCurrentStep() <= 5) {
             Schablone crypt = demonstration.getSchablone();
             cellWidth = width / crypt.getSize();
             cellHeight = cellWidth;

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -81,7 +81,7 @@ public class DemonstrationPainter implements PaintListener {
                 e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 80); //$NON-NLS-1$
                 Color savedColor = e.gc.getForeground();
                 e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-                e.gc.drawString(demonstration.padding.substring(0, Math.min(25, demonstration.padding.length())), 90,
+                e.gc.drawString(demonstration.padding.substring(0, Math.min(25, demonstration.padding.length())), 95,
                         80);
                 for (int i = 25; i < demonstration.padding.length(); i = i + 40)
                     e.gc.drawString(
@@ -189,10 +189,9 @@ public class DemonstrationPainter implements PaintListener {
 
     private void fillCell(PaintEvent e, int x, int y, char c) {
         Point eckeLO = new Point(x * cellWidth, y * cellHeight);
-        int fontSize = (int) Math.round(10 / (double) 17 * cellHeight * 0.9);
+        int fontSize =  (int) (0.5 * cellHeight);
         e.gc.setFont(new Font(Display.getCurrent(), "Times Roman", fontSize, SWT.NORMAL)); //$NON-NLS-1$
-        e.gc.drawString(
-                "" + c, eckeLO.x + (int) Math.round(cellWidth - charSize.get(c).x / (double) 10 * fontSize) / 2, eckeLO.y + (cellHeight - fontSize - (int) Math.round(5 / (double) 10 * fontSize)) / 2); //$NON-NLS-1$
+        e.gc.drawString("" + c, eckeLO.x + (cellWidth / 5), eckeLO.y); //$NON-NLS-1$
     }
 
 }

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -67,21 +67,26 @@ public class DemonstrationPainter implements PaintListener {
     public void paintControl(PaintEvent e) {
         width = parent.getSize().x;
         height = parent.getSize().y;
+        if (width > height) {
+        	width = height;
+        } else {
+        	height = width;
+        }
         if (demonstration.getCurrentStep() == 0) {
             e.gc.fillRectangle(0, 0, width, height);
         } else if (demonstration.getCurrentStep() == 1) {
             e.gc.setFont(FontService.getLargeFont());
             e.gc.drawText(Messages.getString("DemonstrationPainter.description"), 0, 0); //$NON-NLS-1$
             if (!demonstration.padding.equals("")) { //$NON-NLS-1$
-                e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 40); //$NON-NLS-1$
+                e.gc.drawText(Messages.getString("DemonstrationPainter.padding"), 0, 80); //$NON-NLS-1$
                 Color savedColor = e.gc.getForeground();
                 e.gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-                e.gc.drawString(demonstration.padding.substring(0, Math.min(25, demonstration.padding.length())), 70,
-                        40);
+                e.gc.drawString(demonstration.padding.substring(0, Math.min(25, demonstration.padding.length())), 90,
+                        80);
                 for (int i = 25; i < demonstration.padding.length(); i = i + 40)
                     e.gc.drawString(
                             demonstration.padding.substring(i, Math.min(demonstration.padding.length(), i + 40)), 0,
-                            40 + (i / 25) * 20);
+                            95 + (i / 25) * 20);
                 e.gc.setForeground(savedColor);
 
             }

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -70,6 +70,7 @@ public class View extends ViewPart {
     private Composite parent;
 	private Composite viewParent;
 	private Composite inOutText;
+	private Composite composite_illustration;
 
     public View() {
         model = new Grille();
@@ -87,8 +88,7 @@ public class View extends ViewPart {
         createOptions(parent);
         createInOutComposite(parent);
         createSchablone(parent);
-        createDemonstration(parent);
-        createExecutionControls(parent);
+        createIllustrationAndExecType(parent);
 
         scrolledComposite.setContent(parent);
         scrolledComposite.setMinSize(parent.computeSize(SWT.DEFAULT, SWT.DEFAULT));
@@ -97,14 +97,24 @@ public class View extends ViewPart {
         scrolledComposite.layout();
     }
 
-    private void createInOutComposite(Composite parent) {
+    private void createIllustrationAndExecType(Composite parent) {
+    	composite_illustration = new Composite(parent, SWT.NONE);
+    	composite_illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 4, 1));
+    	GridLayout gl_composite_illustration = new GridLayout(2, false);
+    	gl_composite_illustration.marginWidth = 0;
+    	gl_composite_illustration.marginHeight = 0;
+		composite_illustration.setLayout(gl_composite_illustration);
+		createDemonstration(composite_illustration);
+		createExecutionControls(composite_illustration);
+	}
+
+	private void createInOutComposite(Composite parent) {
 		inOutText = new Composite(parent, SWT.NONE);
 		inOutText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 2));
 		// Composite should have no border, so it looks like the groups on the left.
 		GridLayout gl_inOutText = new GridLayout(2, true);
 		gl_inOutText.marginWidth = 0;
 		gl_inOutText.marginHeight = 0;
-		gl_inOutText.verticalSpacing = 0;
 		inOutText.setLayout(gl_inOutText);
 		createInputtext(inOutText);
 		createOutputtext(inOutText);
@@ -130,8 +140,11 @@ public class View extends ViewPart {
     private void createExecutionControls(Composite parent) {
 
         Composite execType = new Composite(parent, SWT.NONE);
-        execType.setLayout(new GridLayout(1, true));
-        execType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+        GridLayout gl_execType = new GridLayout();
+        gl_execType.marginWidth = 0;
+        gl_execType.marginHeight = 0;
+        execType.setLayout(gl_execType);
+        execType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         createTypeSelection(execType);
         createSteps(execType);
 
@@ -390,13 +403,17 @@ public class View extends ViewPart {
         Group illustration = new Group(parent, SWT.NONE);
         illustration.setLayout(new FillLayout());
         illustration.setText(Messages.getString("View.visualisation"));
-        illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
+        illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         canvas_demonstration = new Canvas(illustration, SWT.DOUBLE_BUFFERED);
         canvas_demonstration.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
-        // canvas_demonstration.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
-        // true, false));
-        // canvas_demonstration.addPaintListener(new
-        // DemonstrationPainter(demonstration));
+        
+        int width_Canvas_demonstration = canvas_demonstration.getSize().x;
+        int height_Canvas_demonstration = canvas_demonstration.getSize().y;
+        if (width_Canvas_demonstration >= height_Canvas_demonstration) {
+        	canvas_demonstration.setSize(height_Canvas_demonstration, height_Canvas_demonstration);
+        } else {
+        	canvas_demonstration.setSize(width_Canvas_demonstration, width_Canvas_demonstration);
+        }
     }
 
     private void createInputtext(Composite parent) {

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -69,6 +69,7 @@ public class View extends ViewPart {
     private KeyListener schluessel_listener;
     private Composite parent;
 	private Composite viewParent;
+	private Composite inOutText;
 
     public View() {
         model = new Grille();
@@ -80,12 +81,11 @@ public class View extends ViewPart {
     	this.viewParent = viewParent;
         ScrolledComposite scrolledComposite = new ScrolledComposite(viewParent, SWT.H_SCROLL | SWT.V_SCROLL);
         parent = new Composite(scrolledComposite, SWT.NONE);
-        parent.setLayout(new GridLayout(3, false));
+        parent.setLayout(new GridLayout(4, true));
 
         createDescription(parent);
         createOptions(parent);
-        createInputtext(parent);
-        createOutputtext(parent);
+        createInOutComposite(parent);
         createSchablone(parent);
         createDemonstration(parent);
         createExecutionControls(parent);
@@ -97,9 +97,22 @@ public class View extends ViewPart {
         scrolledComposite.layout();
     }
 
-    private void createOutputtext(Composite parent) {
+    private void createInOutComposite(Composite parent) {
+		inOutText = new Composite(parent, SWT.NONE);
+		inOutText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 2));
+		// Composite should have no border, so it looks like the groups on the left.
+		GridLayout gl_inOutText = new GridLayout(2, true);
+		gl_inOutText.marginWidth = 0;
+		gl_inOutText.marginHeight = 0;
+		gl_inOutText.verticalSpacing = 0;
+		inOutText.setLayout(gl_inOutText);
+		createInputtext(inOutText);
+		createOutputtext(inOutText);
+	}
+
+	private void createOutputtext(Composite parent) {
         group_output = new Group(parent, SWT.NONE);
-        group_output.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 2));
+        group_output.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_output.setLayout(new FillLayout());
         group_output.setText(Messages.getString("View.ciphertext")); //$NON-NLS-1$
         text_output = new Text(group_output, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
@@ -147,10 +160,7 @@ public class View extends ViewPart {
 
                 button_okay = new Button(typeSelection, SWT.NONE);
                 button_okay.setImage(GrillePlugin.getImageDescriptor("icons/run_exc.gif").createImage());
-                GridData gd_button_okay = new GridData(SWT.RIGHT, SWT.CENTER, false, false, 3, 1);
-                gd_button_okay.widthHint = 78;
-                gd_button_okay.heightHint = 39;
-                button_okay.setLayoutData(gd_button_okay);
+                button_okay.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 3, 1));
                 button_okay.setText(Messages.getString("View.start")); //$NON-NLS-1$
                 button_okay.setEnabled(false);
                 button_okay.addSelectionListener(new SelectionListener() {
@@ -379,10 +389,8 @@ public class View extends ViewPart {
     private void createDemonstration(Composite parent) {
         Group illustration = new Group(parent, SWT.NONE);
         illustration.setLayout(new FillLayout());
-        illustration.setText(Messages.getString("View.visualisation")); //$NON-NLS-1$
-        GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, false);
-        gridData.widthHint = 300;
-        illustration.setLayoutData(gridData);
+        illustration.setText(Messages.getString("View.visualisation"));
+        illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
         canvas_demonstration = new Canvas(illustration, SWT.DOUBLE_BUFFERED);
         canvas_demonstration.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
         // canvas_demonstration.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
@@ -393,7 +401,7 @@ public class View extends ViewPart {
 
     private void createInputtext(Composite parent) {
         group_input = new Group(parent, SWT.NONE);
-        group_input.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 2));
+        group_input.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_input.setLayout(new FillLayout());
         group_input.setText(Messages.getString("View.plaintext")); //$NON-NLS-1$
         text_input = new Text(group_input, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
@@ -498,7 +506,7 @@ public class View extends ViewPart {
     private void createDescription(Composite parent) {
         Composite compositeIntro = new Composite(parent, SWT.NONE);
         compositeIntro.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
-        compositeIntro.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+        compositeIntro.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 4, 1));
         compositeIntro.setLayout(new GridLayout(1, false));
 
         Label label = new Label(compositeIntro, SWT.NONE);

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -25,12 +25,15 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.ToolTip;
 import org.eclipse.ui.part.ViewPart;
 import org.jcryptool.core.util.fonts.FontService;
 import org.jcryptool.visual.grille.GrillePlugin;
@@ -108,6 +111,20 @@ public class View extends ViewPart {
 		composite_illustration.setLayout(gl_composite_illustration);
 		createDemonstration(composite_illustration);
 		createExecutionControls(composite_illustration);
+		
+		final ToolTip tip = new ToolTip(composite_illustration.getShell(), SWT.BALLOON);
+		tip.setMessage(Messages.getString("View.2")); //$NON-NLS-1$
+		
+		Label help = new Label(composite_illustration, SWT.NONE);
+		help.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
+		help.setImage(GrillePlugin.getImageDescriptor("platform:/plugin/org.eclipse.ui/icons/full/etool16/help_contents.png").createImage()); //$NON-NLS-1$
+		help.addListener(SWT.MouseDown, new Listener() {
+			
+			@Override
+			public void handleEvent(Event event) {
+				tip.setVisible(true);
+			}
+		});
 	}
 
 	private void createInOutComposite(Composite parent) {
@@ -158,7 +175,7 @@ public class View extends ViewPart {
         gl_execType.marginWidth = 0;
         gl_execType.marginHeight = 0;
         execType.setLayout(gl_execType);
-        execType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        execType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 2));
         createTypeSelection(execType);
         createSteps(execType);
 
@@ -417,7 +434,7 @@ public class View extends ViewPart {
         Group illustration = new Group(parent, SWT.NONE);
         illustration.setLayout(new FillLayout());
         illustration.setText(Messages.getString("View.visualisation")); //$NON-NLS-1$
-        illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         canvas_demonstration = new Canvas(illustration, SWT.DOUBLE_BUFFERED);
         canvas_demonstration.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
         

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -124,16 +124,28 @@ public class View extends ViewPart {
         group_output = new Group(parent, SWT.NONE);
         group_output.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_output.setLayout(new FillLayout());
-        group_output.setText(Messages.getString("View.ciphertext")); //$NON-NLS-1$
+        group_output.setText(Messages.getString("View.ciphertext") + " (0)");
         text_output = new Text(group_output, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
         text_output.addKeyListener(new org.eclipse.swt.events.KeyListener() {
+        	
+        	@Override
             public void keyPressed(KeyEvent e) {
                 e.doit = false;
             }
 
+        	@Override
             public void keyReleased(KeyEvent e) {
+        		
             }
         });
+        
+        text_output.addModifyListener(new ModifyListener() {
+			
+			@Override
+			public void modifyText(ModifyEvent e) {
+				group_output.setText(Messages.getString("View.ciphertext") + " (" + text_output.getText().length() + ")");
+			}
+		});
 
     }
 
@@ -420,10 +432,14 @@ public class View extends ViewPart {
         group_input = new Group(parent, SWT.NONE);
         group_input.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_input.setLayout(new FillLayout());
-        group_input.setText(Messages.getString("View.plaintext")); //$NON-NLS-1$
+        group_input.setText(Messages.getString("View.plaintext") + " (0)");
         text_input = new Text(group_input, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
+        text_input.setText("");
         text_input.addModifyListener(new ModifyListener() {
+        	
+        	@Override
             public void modifyText(ModifyEvent e) {
+        		group_input.setText(Messages.getString("View.plaintext") + " (" + text_input.getText().length() + ")");
                 reset();
             }
         });
@@ -474,6 +490,8 @@ public class View extends ViewPart {
                 checkOkButton();
             }
         });
+        
+        
     }
 
     private void createOptions(Composite parent) {

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -51,6 +51,8 @@ public class View extends ViewPart {
     private Button button_step1;
     private Button button_direct;
     private Button button_stepwise;
+    private Button setHoles;
+    private Button deleteHoles;
     private Text text_output;
     private Button button_okay;
     private Spinner spinner_keySize;
@@ -82,7 +84,7 @@ public class View extends ViewPart {
     	this.viewParent = viewParent;
         ScrolledComposite scrolledComposite = new ScrolledComposite(viewParent, SWT.H_SCROLL | SWT.V_SCROLL);
         parent = new Composite(scrolledComposite, SWT.NONE);
-        parent.setLayout(new GridLayout(4, true));
+        parent.setLayout(new GridLayout(4, false));
 
         createDescription(parent);
         createOptions(parent);
@@ -124,7 +126,7 @@ public class View extends ViewPart {
         group_output = new Group(parent, SWT.NONE);
         group_output.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_output.setLayout(new FillLayout());
-        group_output.setText(Messages.getString("View.ciphertext") + " (0)");
+        group_output.setText(Messages.getString("View.ciphertext") + " (0)"); //$NON-NLS-1$ //$NON-NLS-2$
         text_output = new Text(group_output, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
         text_output.addKeyListener(new org.eclipse.swt.events.KeyListener() {
         	
@@ -143,7 +145,7 @@ public class View extends ViewPart {
 			
 			@Override
 			public void modifyText(ModifyEvent e) {
-				group_output.setText(Messages.getString("View.ciphertext") + " (" + text_output.getText().length() + ")");
+				group_output.setText(Messages.getString("View.ciphertext") + " (" + text_output.getText().length() + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
 		});
 
@@ -166,7 +168,7 @@ public class View extends ViewPart {
 
         Group typeSelection = new Group(execType, SWT.NONE);
         typeSelection.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
-        typeSelection.setText(Messages.getString("View.type"));
+        typeSelection.setText(Messages.getString("View.type")); //$NON-NLS-1$
         typeSelection.setLayout(new GridLayout(3, true));
 
         button_direct = new Button(typeSelection, SWT.RADIO);
@@ -184,7 +186,7 @@ public class View extends ViewPart {
         });
 
                 button_okay = new Button(typeSelection, SWT.NONE);
-                button_okay.setImage(GrillePlugin.getImageDescriptor("icons/run_exc.gif").createImage());
+                button_okay.setImage(GrillePlugin.getImageDescriptor("icons/run_exc.gif").createImage()); //$NON-NLS-1$
                 button_okay.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 3, 1));
                 button_okay.setText(Messages.getString("View.start")); //$NON-NLS-1$
                 button_okay.setEnabled(false);
@@ -248,7 +250,7 @@ public class View extends ViewPart {
 
         Group steps = new Group(execType, SWT.NONE);
         steps.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
-        steps.setText(Messages.getString("View.steps"));
+        steps.setText(Messages.getString("View.steps")); //$NON-NLS-1$
         steps.setLayout(new GridLayout(1, true));
 
         Group step1 = new Group(steps, SWT.NONE);
@@ -414,7 +416,7 @@ public class View extends ViewPart {
     private void createDemonstration(Composite parent) {
         Group illustration = new Group(parent, SWT.NONE);
         illustration.setLayout(new FillLayout());
-        illustration.setText(Messages.getString("View.visualisation"));
+        illustration.setText(Messages.getString("View.visualisation")); //$NON-NLS-1$
         illustration.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         canvas_demonstration = new Canvas(illustration, SWT.DOUBLE_BUFFERED);
         canvas_demonstration.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
@@ -432,14 +434,14 @@ public class View extends ViewPart {
         group_input = new Group(parent, SWT.NONE);
         group_input.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         group_input.setLayout(new FillLayout());
-        group_input.setText(Messages.getString("View.plaintext") + " (0)");
+        group_input.setText(Messages.getString("View.plaintext") + " (0)"); //$NON-NLS-1$ //$NON-NLS-2$
         text_input = new Text(group_input, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
-        text_input.setText("");
+        text_input.setText(""); //$NON-NLS-1$
         text_input.addModifyListener(new ModifyListener() {
         	
         	@Override
             public void modifyText(ModifyEvent e) {
-        		group_input.setText(Messages.getString("View.plaintext") + " (" + text_input.getText().length() + ")");
+        		group_input.setText(Messages.getString("View.plaintext") + " (" + text_input.getText().length() + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 reset();
             }
         });
@@ -448,7 +450,7 @@ public class View extends ViewPart {
     private void createSchablone(Composite parent) {
         Group schablone = new Group(parent, SWT.NONE);
         schablone.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
-        schablone.setLayout(new GridLayout(2, true));
+        schablone.setLayout(new GridLayout(2, false));
         schablone.setText(Messages.getString("View.keygrille")); //$NON-NLS-1$
 
         canvas_schluessel = new Canvas(schablone, SWT.DOUBLE_BUFFERED);
@@ -456,14 +458,14 @@ public class View extends ViewPart {
         canvas_schluessel.addPaintListener(new KeyPainter(canvas_schluessel, model));
         schluessel_listener = new KeyListener(model, this);
         canvas_schluessel.addMouseListener(schluessel_listener);
-        GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2);
+        GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, true, 1, 4);
         gridData.widthHint = 151;
         gridData.heightHint = 151;
         canvas_schluessel.setLayoutData(gridData);
 
         Label spinner = new Label(schablone, SWT.NONE);
         spinner.setText(Messages.getString("View.size")); //$NON-NLS-1$
-        spinner.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 1, 1));
+        spinner.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false));
 
         spinner_keySize = new Spinner(schablone, SWT.NONE);
         spinner_keySize.setMinimum(4);
@@ -471,7 +473,7 @@ public class View extends ViewPart {
         spinner_keySize.setIncrement(2);
         spinner_keySize.setSelection(6);
         spinner_keySize.setEnabled(true);
-        spinner_keySize.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
+        spinner_keySize.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, true));
     	
         spinner_keySize.addSelectionListener(new SelectionListener() {
             public void widgetDefaultSelected(SelectionEvent e) {
@@ -486,10 +488,70 @@ public class View extends ViewPart {
                 reset();
                 canvas_schluessel.removeMouseListener(schluessel_listener);
                 canvas_schluessel.addMouseListener(schluessel_listener);
-                canvas_schluessel.redraw();
-                checkOkButton();
             }
         });
+        
+        setHoles = new Button(schablone, SWT.PUSH);
+        setHoles.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, true));
+        setHoles.setText(Messages.getString("View.1")); //$NON-NLS-1$
+        setHoles.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				//reset the old schablone
+				model.setKey(new KeySchablone(Integer.parseInt(spinner_keySize.getText())));
+				reset();
+                
+                boolean set = false;
+				int size = model.getKey().getSize();
+				int x = (int) (Math.random() * (size - 1) + 1);
+				int y = (int) (Math.random() * (size - 1) + 1);
+
+				do {
+					for (int i = 0; i < 6; i++) {
+						if (model.getKey().get((x + i) % size, y % size) == '0') {
+							model.getKey().toggle((x + i) % size, y % size);
+							y++;
+							x++;
+							break;
+						}
+					}
+					if (!set) {
+						y++;
+					}
+				} while (!model.getKey().isValid());
+				
+				canvas_schluessel.redraw();
+                canvas_schluessel.removeMouseListener(schluessel_listener);
+                canvas_schluessel.addMouseListener(schluessel_listener);
+                checkOkButton();
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				widgetSelected(e);
+				
+			}
+		});
+        
+        deleteHoles = new Button(schablone, SWT.PUSH);
+        deleteHoles.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false));
+        deleteHoles.setText(Messages.getString("View.0")); //$NON-NLS-1$
+        deleteHoles.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				model.setKey(new KeySchablone(Integer.parseInt(spinner_keySize.getText())));
+				reset();
+                canvas_schluessel.removeMouseListener(schluessel_listener);
+                canvas_schluessel.addMouseListener(schluessel_listener);
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				widgetSelected(e);
+			}
+		});
         
         
     }
@@ -533,7 +595,7 @@ public class View extends ViewPart {
                 button_stepwise.setSelection(false);
                 button_direct.setSelection(true);
                 text_input.setText(text_output.getText());
-                text_output.setText("");
+                text_output.setText(""); //$NON-NLS-1$
             }
         });
     }
@@ -573,7 +635,6 @@ public class View extends ViewPart {
         label_step4.setEnabled(false);
         label_step5.setEnabled(false);
         label_step6.setEnabled(false);
-       // text_output.setText(""); //$NON-NLS-1$
         canvas_demonstration.redraw();
         canvas_schluessel.redraw();
     }

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
@@ -1,4 +1,4 @@
-DemonstrationPainter.description=The length of the entered text is checked\nand corrected if needed.
+DemonstrationPainter.description=The length of the entered text is \nchecked and adapted if necessary \n(extended by a padding of length mm).
 DemonstrationPainter.padding=Padding:
 View.check=Input text is checked
 View.ciphertext=Ciphertext

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
@@ -2,6 +2,7 @@ DemonstrationPainter.description=The length of the entered text is \nchecked and
 DemonstrationPainter.padding=Padding
 View.0=Remove holes
 View.1=Put holes randomly
+View.2=In this area, the encryption process is visualized.
 View.check=Remove holes
 View.ciphertext=Ciphertext
 View.decryption=Decryption

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
@@ -1,5 +1,5 @@
 DemonstrationPainter.description=The length of the entered text is \nchecked and adapted if necessary \n(extended by a padding).
-DemonstrationPainter.padding=Padding:
+DemonstrationPainter.padding=Padding
 View.0=Remove holes
 View.1=Put holes randomly
 View.check=Remove holes

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages.properties
@@ -1,6 +1,8 @@
-DemonstrationPainter.description=The length of the entered text is \nchecked and adapted if necessary \n(extended by a padding of length mm).
+DemonstrationPainter.description=The length of the entered text is \nchecked and adapted if necessary \n(extended by a padding).
 DemonstrationPainter.padding=Padding:
-View.check=Input text is checked
+View.0=Remove holes
+View.1=Put holes randomly
+View.check=Remove holes
 View.ciphertext=Ciphertext
 View.decryption=Decryption
 View.description1=The grille encryption system is a classic transposition cipher. The encryption is done with a squared grille getting turned while writing the plaintext.\n

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
@@ -1,5 +1,5 @@
 DemonstrationPainter.description=Die L\u00E4nge des eingegebenen Textes\nwird \u00FCberpr\u00FCft und gegebenenfalls\nangepasst (um das Padding \nverl\u00E4ngert).
-DemonstrationPainter.padding=Padding:
+DemonstrationPainter.padding=Padding
 View.check=\u00DCberpr\u00FCfung der Texteingabe
 View.ciphertext=Chiffretext
 View.decryption=Entschl\u00FCsseln

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
@@ -34,3 +34,4 @@ View.title=Das Grille-Verschl\u00FCsselungsverfahren
 View.visualisation=Visualisierung
 View.0=L\u00F6cher entfernen
 View.1=L\u00F6cher zuf\u00E4llig setzen
+View.2=In diesem Bereich wird der Ablauf der Verschl\u00fcsselung visualisiert.

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
@@ -1,4 +1,4 @@
-DemonstrationPainter.description=Die L\u00E4nge des eingegebenen Textes\nwird \u00FCberpr\u00FCft und gegebenenfalls\nangepasst (um ein padding der \nL\u00E4nge mm verl\u00E4ngert).
+DemonstrationPainter.description=Die L\u00E4nge des eingegebenen Textes\nwird \u00FCberpr\u00FCft und gegebenenfalls\nangepasst (um das Padding \nverl\u00E4ngert).
 DemonstrationPainter.padding=Padding:
 View.check=\u00DCberpr\u00FCfung der Texteingabe
 View.ciphertext=Chiffretext
@@ -32,3 +32,5 @@ View.stepwise=Schrittweise
 View.third_turn=Schablonendurchlauf nach 180\u00B0-Drehung
 View.title=Das Grille-Verschl\u00FCsselungsverfahren
 View.visualisation=Visualisierung
+View.0=L\u00F6cher entfernen
+View.1=L\u00F6cher zuf\u00E4llig setzen

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/messages_de.properties
@@ -1,4 +1,4 @@
-DemonstrationPainter.description=Die L\u00E4nge des eingegebenen Textes wird \n\u00FCberpr\u00FCft und gegebenenfalls angepasst.
+DemonstrationPainter.description=Die L\u00E4nge des eingegebenen Textes\nwird \u00FCberpr\u00FCft und gegebenenfalls\nangepasst (um ein padding der \nL\u00E4nge mm verl\u00E4ngert).
 DemonstrationPainter.padding=Padding:
 View.check=\u00DCberpr\u00FCfung der Texteingabe
 View.ciphertext=Chiffretext


### PR DESCRIPTION
Addresses #117 
The distribution of free space changed. The visualization now has about 1/3 of the space, the group with the buttons 2/3. 
The letters in the visualization now fit better in the given boxes. 
The text displayed in step 1 of the visualization now fits in the given space.
The visualization itself is now scalable. It is always square, which is why a white border can form to the right or bottom as the window size changes.
<img width="751" alt="gril_voz_old" src="https://user-images.githubusercontent.com/20046726/32323774-6c61f5a6-bfc9-11e7-80f1-8a4ccd9d5900.PNG">
<img width="751" alt="grille_viz_text" src="https://user-images.githubusercontent.com/20046726/32323776-6facf800-bfc9-11e7-8239-1c7ed406dadd.PNG">
<img width="755" alt="grille_viz_old2" src="https://user-images.githubusercontent.com/20046726/32323781-72a7ac8a-bfc9-11e7-9d20-bdc6f468e72b.PNG">
<img width="754" alt="grille_viz_whiteborder" src="https://user-images.githubusercontent.com/20046726/32323785-745df02a-bfc9-11e7-8356-c84d5a78ed70.PNG">

