### PR TITLE
Button "Step 2" becomes disabled if you press "Step 2"

### DIFF
--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CRTGroup.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CRTGroup.java
@@ -248,6 +248,7 @@ public class CRTGroup extends Composite implements Constants {
                     step2Text.setFont(FontService.getSmallBoldFont());
                     execute = true;
                     step1Group.setEnabled(false);
+                	step1nextButton.setEnabled(false);
                     step2Group.setEnabled(true);
                     step2Text.setEnabled(true);
                     step2nextButton.setEnabled(true);


### PR DESCRIPTION
Button "Step 2" was not disabled after the last PR. This is fixed now.
<img width="595" alt="crt_bug_fix" src="https://user-images.githubusercontent.com/20046726/32716644-0c08f31c-c857-11e7-9e0e-0ea95c4f78ca.PNG">
