### PR TITLE
GUI fixes in ECC

### DIFF
--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages.properties
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages.properties
@@ -6,15 +6,15 @@ ECContentFm.3=Deselects the highlighted points
 ECContentFm.4=This entry depends on the choice of m and f.
 ECContentFm.40=Show binary values
 ECContentFm.45=Calculations
-ECContentFm.46=Please choose P with your mouse and select how to choose Q:
-ECContentFm.47=Choose Q also with your mouse
+ECContentFm.46=Please choose P with your mouse and select how\nto choose Q:
+ECContentFm.47=Choose Q also with your mouse.
 ECContentFm.48=Choose Q as k*P with k =
 ECContentFm.49=Results:
 ECContentFp.0=Elliptic Curve  (y\u00b2 mod p = (x\u00b3 + ax + b) mod p)
-ECContentFp.1=Please choose P in the graphic with your mouse and select how to choose Q:
+ECContentFp.1=Please choose P in the graphic with your mouse and\nselect how to choose Q:
 ECContentFp.3=Deselects the highlighted points
 ECContentFp.37=Calculations
-ECContentFp.39=Choose Q also with your mouse
+ECContentFp.39=Choose Q also with your mouse.
 ECContentFp.40=Choose Q as k*P with k =
 ECContentFp.41=Results:
 ECContentFp.6=Settings
@@ -24,8 +24,8 @@ ECContentLarge.18=Multiply P by k
 ECContentReal.0=Elliptic Curve  (y\u00b2 = x\u00b3 + ax + b)
 ECContentReal.3=Deselects the highlighted points
 ECContentReal.35=Calculations
-ECContentReal.36=Please choose P in the graphic with your mouse and select how to choose Q:
-ECContentReal.37=Choose Q also with your mouse
+ECContentReal.36=Please choose P in the graphic with your mouse\nand select how to choose Q:
+ECContentReal.37=Choose Q also with your mouse.
 ECContentReal.38=Choose Q as k*P with k =
 ECContentReal.39=Results:
 ECContentReal.9=Settings

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
@@ -6,15 +6,15 @@ ECContentFm.3=Abw\u00e4hlen der markierten Punkte
 ECContentFm.4=Die Auswahl von b ist abh\u00E4nig von m und f.
 ECContentFm.40=Zeige bin\u00e4re Werte
 ECContentFm.45=Berechnungen
-ECContentFm.46=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die Methode f\u00fcr Q:
-ECContentFm.47=Q ebenfalls mit der Maus w\u00e4hlen
+ECContentFm.46=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die\nMethode f\u00fcr Q:
+ECContentFm.47=Q ebenfalls mit der Maus w\u00e4hlen.
 ECContentFm.48=Q ist k*P mit k =
 ECContentFm.49=Ergebnisse:
 ECContentFp.0=Elliptische Kurve  (y\u00b2 mod p = (x\u00b3 + ax + b) mod p)
-ECContentFp.1=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die Methode f\u00fcr Q:
+ECContentFp.1=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die\nMethode f\u00fcr Q:
 ECContentFp.3=Abw\u00e4hlen der markierten Punkte
 ECContentFp.37=Berechnungen
-ECContentFp.39=Q ebenfalls mit der Maus w\u00e4hlen
+ECContentFp.39=Q ebenfalls mit der Maus w\u00e4hlen.
 ECContentFp.40=Q ist k*P mit k =
 ECContentFp.41=Ergebnisse:
 ECContentFp.6=Einstellungen
@@ -24,8 +24,8 @@ ECContentLarge.18=P mit k multiplizieren
 ECContentReal.0=Elliptische Kurve  (y\u00b2 = x\u00b3 + ax + b)
 ECContentReal.3=Abw\u00e4hlen der markierten Punkte
 ECContentReal.35=Berechnungen
-ECContentReal.36=Bitte w\u00e4hlen Sie P in der Grafik mit der Maus und w\u00e4hlen Sie die Methode f\u00fcr Q:
-ECContentReal.37=Q ebenfalls mit der Maus w\u00e4hlen
+ECContentReal.36=Bitte w\u00e4hlen Sie P in der Grafik mit der Maus und\nw\u00e4hlen Sie die Methode f\u00fcr Q:
+ECContentReal.37=Q ebenfalls mit der Maus w\u00e4hlen.
 ECContentReal.38=Q ist k*P mit k =
 ECContentReal.39=Ergebnisse:
 ECContentReal.9=Einstellungen

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
@@ -107,6 +107,7 @@ public class ECContentFm extends Composite{
 	private Composite content;
 	private Group groupSize;
 	private Button rbtnSmall;
+    private ScrolledComposite scrolledCompositeSettings;
 
 
 	public ECContentFm(Composite parent, int style, ECView view) {
@@ -122,7 +123,6 @@ public class ECContentFm extends Composite{
 
 
 		GridLayout gridLayout = new GridLayout(2, false);
-		gridLayout.verticalSpacing = 2;
 		content.setLayout(gridLayout);
 
 		createCompositeIntro();
@@ -231,18 +231,27 @@ public class ECContentFm extends Composite{
 	 *
 	 */
 	private void createGroupSettings() {
-		groupSettings = new Group(content, SWT.NONE);
-		groupSettings.setText(Messages.getString("ECContentFm.15")); //$NON-NLS-1$
-		groupSettings.setLayout(new GridLayout(1, false));
-		GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2);
-		gridData.widthHint = 300;
-		groupSettings.setLayoutData(gridData);
+    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
+    	scrolledCompositeSettings.setExpandVertical(true);
+    	scrolledCompositeSettings.setExpandHorizontal(true);
+    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
+    	scrolledCompositeSettings.setLayout(new GridLayout());
+    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
+    	
+    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+        groupSettings.setText(Messages.getString("ECContentFm.15")); //$NON-NLS-1$
+        groupSettings.setLayout(new GridLayout());
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        
 		createGroupSize();
 		createGroupCurveType();
 		createGroupCurveAttributes();
 		createGroupCalculations();
 		createGroupSave();
 		createGroupElements();
+		
+        scrolledCompositeSettings.setContent(groupSettings);
+        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**
@@ -488,9 +497,9 @@ public class ECContentFm extends Composite{
 		if(curve == null)
 			curve = new ECFm();
 
-		GridData gridData1 = new GridData();
-		gridData1.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData1.widthHint = 100;
+//		GridData gridData1 = new GridData();
+//		gridData1.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
+//		gridData1.widthHint = 100;
 		Label label2 = new Label(groupCurveAttributes, SWT.NONE);
 		label2.setText("m ="); //$NON-NLS-1$
 		spnrM = new Spinner(groupCurveAttributes, SWT.BORDER);
@@ -510,7 +519,10 @@ public class ECContentFm extends Composite{
 				updateCurve(true);
 			}
 		});
-		spnrM.setLayoutData(gridData1);
+//		spnrM.setLayoutData(gridData1);
+		GridData gd_spnrM = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		gd_spnrM.widthHint = 100;
+		spnrM.setLayoutData(gd_spnrM);
 		((ECFm) curve).setM(spnrM.getSelection());
 
 
@@ -536,12 +548,18 @@ public class ECContentFm extends Composite{
 			}
 		});
 		cF.setToolTipText(Messages.getString("ECContentFm.1")); //$NON-NLS-1$
-		cF.setLayoutData(gridData1);
+//		cF.setLayoutData(gridData1);
+		GridData gd_cF = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		gd_cF.widthHint = 100;
+		cF.setLayoutData(gd_cF);
 		((ECFm) curve).setF(cF.getSelectionIndex(), true);
 		Label label = new Label(groupCurveAttributes, SWT.NONE);
 		label.setText("a ="); //$NON-NLS-1$
 		cA = new Combo(groupCurveAttributes, SWT.READ_ONLY);
-		cA.setLayoutData(gridData1);
+//		cA.setLayoutData(gridData1);
+		GridData gd_cA = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		gd_cA.widthHint = 100;
+		cA.setLayoutData(gd_cA);
 		cA.addSelectionListener(new SelectionListener(){
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
 			public void widgetSelected(SelectionEvent e) {
@@ -563,7 +581,10 @@ public class ECContentFm extends Composite{
 			}
 		});
 		cB.setToolTipText(Messages.getString("ECContentFm.4")); //$NON-NLS-1$
-		cB.setLayoutData(gridData1);
+//		cB.setLayoutData(gridData1);
+		GridData gd_cB = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		gd_cB.widthHint = 100;
+		cB.setLayoutData(gd_cB);
 		GridData gridData = new GridData();
 		gridData.horizontalSpan = 2;
 		cbShowBinary = new Button(groupCurveAttributes, SWT.CHECK);
@@ -628,7 +649,8 @@ public class ECContentFm extends Composite{
 		label.setBackground(white);
 		label.setText(Messages.getString("ECView.Title")); //$NON-NLS-1$
 
-		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+//		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY | SWT.WRAP);
 		stDescription.setText(Messages.getString("ECView.Description")); //$NON-NLS-1$
 		stDescription.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 	}

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
@@ -107,7 +107,6 @@ public class ECContentFm extends Composite{
 	private Composite content;
 	private Group groupSize;
 	private Button rbtnSmall;
-    private ScrolledComposite scrolledCompositeSettings;
 
 
 	public ECContentFm(Composite parent, int style, ECView view) {
@@ -130,7 +129,7 @@ public class ECContentFm extends Composite{
 		createGroupSettings();
 
 		scrolledComposite.setContent(content);
-		scrolledComposite.setMinSize(content.computeSize(862, 804));
+		scrolledComposite.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
 		createGroupAttributesFm();
 		createGroupPoints();
@@ -231,17 +230,10 @@ public class ECContentFm extends Composite{
 	 *
 	 */
 	private void createGroupSettings() {
-    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
-    	scrolledCompositeSettings.setExpandVertical(true);
-    	scrolledCompositeSettings.setExpandHorizontal(true);
-    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
-    	scrolledCompositeSettings.setLayout(new GridLayout());
-    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
-    	
-    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+    	groupSettings = new Group(content, SWT.NONE);
         groupSettings.setText(Messages.getString("ECContentFm.15")); //$NON-NLS-1$
         groupSettings.setLayout(new GridLayout());
-        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
         
 		createGroupSize();
 		createGroupCurveType();
@@ -249,9 +241,6 @@ public class ECContentFm extends Composite{
 		createGroupCalculations();
 		createGroupSave();
 		createGroupElements();
-		
-        scrolledCompositeSettings.setContent(groupSettings);
-        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
@@ -103,7 +103,6 @@ public class ECContentFp extends Composite{
 	private Composite content;
 	private Group groupSize;
 	private Button rbtnSmall;
-    private ScrolledComposite scrolledCompositeSettings;
 
 
 	public ECContentFp(Composite parent, int style, ECView view) {
@@ -118,7 +117,6 @@ public class ECContentFp extends Composite{
 		content = new Composite(scrolledComposite, SWT.NONE);
 
 		GridLayout gridLayout = new GridLayout(2, false);
-//		gridLayout.verticalSpacing = 2;
 		content.setLayout(gridLayout);
 
 		createCompositeIntro();
@@ -126,7 +124,7 @@ public class ECContentFp extends Composite{
 		createGroupSettings();
 
 		scrolledComposite.setContent(content);
-		scrolledComposite.setMinSize(content.computeSize(862, 804));
+		scrolledComposite.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
 		createGroupAttributesFp();
 		createGroupPoints();
@@ -197,26 +195,16 @@ public class ECContentFp extends Composite{
 	 *
 	 */
 	private void createGroupSettings() {
-    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
-    	scrolledCompositeSettings.setExpandVertical(true);
-    	scrolledCompositeSettings.setExpandHorizontal(true);
-    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
-    	scrolledCompositeSettings.setLayout(new GridLayout());
-    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
-    	
-    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+		groupSettings = new Group(content, SWT.NONE);
         groupSettings.setText(Messages.getString("ECContentFp.6")); //$NON-NLS-1$
         groupSettings.setLayout(new GridLayout());
-        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
 		
 		createGroupSize();
 		createGroupCurveType();
 		createGroupCurveAttributes();
 		createGroupCalculations();
 		createGroupSave();
-		
-        scrolledCompositeSettings.setContent(groupSettings);
-        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
@@ -103,6 +103,7 @@ public class ECContentFp extends Composite{
 	private Composite content;
 	private Group groupSize;
 	private Button rbtnSmall;
+    private ScrolledComposite scrolledCompositeSettings;
 
 
 	public ECContentFp(Composite parent, int style, ECView view) {
@@ -117,7 +118,7 @@ public class ECContentFp extends Composite{
 		content = new Composite(scrolledComposite, SWT.NONE);
 
 		GridLayout gridLayout = new GridLayout(2, false);
-		gridLayout.verticalSpacing = 2;
+//		gridLayout.verticalSpacing = 2;
 		content.setLayout(gridLayout);
 
 		createCompositeIntro();
@@ -196,17 +197,26 @@ public class ECContentFp extends Composite{
 	 *
 	 */
 	private void createGroupSettings() {
-		groupSettings = new Group(content, SWT.NONE);
-		groupSettings.setText(Messages.getString("ECContentFp.6")); //$NON-NLS-1$
-		groupSettings.setLayout(new GridLayout(1, false));
-		GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2);
-		gridData.widthHint = 300;
-		groupSettings.setLayoutData(gridData);
+    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
+    	scrolledCompositeSettings.setExpandVertical(true);
+    	scrolledCompositeSettings.setExpandHorizontal(true);
+    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true, 1, 2));
+    	scrolledCompositeSettings.setLayout(new GridLayout());
+    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
+    	
+    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+        groupSettings.setText(Messages.getString("ECContentFp.6")); //$NON-NLS-1$
+        groupSettings.setLayout(new GridLayout());
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
 		createGroupSize();
 		createGroupCurveType();
 		createGroupCurveAttributes();
 		createGroupCalculations();
 		createGroupSave();
+		
+        scrolledCompositeSettings.setContent(groupSettings);
+        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**
@@ -574,7 +584,8 @@ public class ECContentFp extends Composite{
 		label.setBackground(white);
 		label.setText(Messages.getString("ECView.Title")); //$NON-NLS-1$
 
-		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+//		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY | SWT.WRAP);
 		stDescription.setText(Messages.getString("ECView.Description")); //$NON-NLS-1$
 		stDescription.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 	}

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
@@ -111,6 +111,7 @@ public class ECContentLarge extends Composite {
 	private Button btnSave = null;
 	private Label lblP = null;
 	private Composite content;
+    private ScrolledComposite scrolledCompositeSettings;
 
 	public ECContentLarge(Composite parent, int style, ECView v) {
 		super(parent, style);
@@ -186,7 +187,8 @@ public class ECContentLarge extends Composite {
 		label.setBackground(white);
 		label.setText(Messages.getString("ECView.Title")); //$NON-NLS-1$
 
-		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+//		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+		stDescription = new StyledText(compositeIntro, SWT.READ_ONLY | SWT.WRAP);
 		stDescription.setText(Messages.getString("ECView.LargeDescription")); //$NON-NLS-1$
 		stDescription.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 	}
@@ -196,20 +198,27 @@ public class ECContentLarge extends Composite {
 	 *
 	 */
 	private void createGroupSettings() {
-		GridData gridData2 = new GridData();
-		gridData2.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData2.widthHint = 300;
-		gridData2.verticalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		groupSettings = new Group(content, SWT.NONE);
-		groupSettings.setLayout(new GridLayout());
-		groupSettings.setText(Messages.getString("ECView.Settings")); //$NON-NLS-1$
-		groupSettings.setLayoutData(gridData2);
+    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
+    	scrolledCompositeSettings.setExpandVertical(true);
+    	scrolledCompositeSettings.setExpandHorizontal(true);
+    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
+    	scrolledCompositeSettings.setLayout(new GridLayout());
+    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
+    	
+    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+        groupSettings.setText(Messages.getString("ECView.Settings")); //$NON-NLS-1$
+        groupSettings.setLayout(new GridLayout());
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        
 		createGroupSize();
 		createGroupType();
 		createGroupSelectAttributes();
 		createGroupRadix();
 		createGroupCalculations();
 		createGroupSave();
+		
+        scrolledCompositeSettings.setContent(groupSettings);
+        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**
@@ -417,13 +426,11 @@ public class ECContentLarge extends Composite {
 	 *
 	 */
 	private void createGroupCurve() {
-		GridData gridData8 = new GridData();
-		gridData8.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData8.grabExcessHorizontalSpace = true;
-		gridData8.verticalAlignment = org.eclipse.swt.layout.GridData.FILL;
 		groupCurve = new Group(content, SWT.NONE);
 		groupCurve.setLayout(new GridLayout());
-		groupCurve.setLayoutData(gridData8);
+		GridData gd_groupCurve = new GridData(SWT.FILL, SWT.FILL, true, false);
+		gd_groupCurve.minimumWidth = 700;
+		groupCurve.setLayoutData(gd_groupCurve);
 		createGroupAttributes();
 		groupCurve.setText(Messages.getString("ECView.EllipticCurve")); //$NON-NLS-1$
 		createGroupP();
@@ -703,31 +710,14 @@ public class ECContentLarge extends Composite {
 	 *
 	 */
 	private void createGroupP() {
-		GridData gridData44 = new GridData();
-		gridData44.horizontalAlignment = org.eclipse.swt.layout.GridData.END;
-		GridData gridData34 = new GridData();
-		gridData34.horizontalSpan = 3;
-		gridData34.grabExcessHorizontalSpace = true;
-		gridData34.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		GridData gridData33 = new GridData();
-		gridData33.horizontalSpan = 2;
-		GridData gridData32 = new GridData();
-		gridData32.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData32.horizontalSpan = 3;
-		gridData32.grabExcessHorizontalSpace = true;
-		GridLayout gridLayout6 = new GridLayout();
-		gridLayout6.numColumns = 4;
-		GridData gridData31 = new GridData();
-		gridData31.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData31.grabExcessHorizontalSpace = true;
-		gridData31.verticalAlignment = org.eclipse.swt.layout.GridData.FILL;
 		groupP = new Group(groupCurve, SWT.NONE);
-		groupP.setLayoutData(gridData31);
-		groupP.setLayout(gridLayout6);
+		groupP.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		groupP.setLayout(new GridLayout(4, false));
 		groupP.setText(Messages.getString("ECView.Point") + " P"); //$NON-NLS-1$ //$NON-NLS-2$
+		
 		btnPGenerate = new Button(groupP, SWT.NONE);
 		btnPGenerate.setText(Messages.getString("ECView.GenerateRandomPoint")); //$NON-NLS-1$
-		btnPGenerate.setLayoutData(gridData33);
+		btnPGenerate.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		btnPGenerate.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) { }
 			public void widgetSelected(SelectionEvent e) {
@@ -764,7 +754,9 @@ public class ECContentLarge extends Composite {
 				}
 			}
 		});
+		
 		btnPGenerator = new Button(groupP, SWT.NONE);
+		btnPGenerator.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		btnPGenerator.setText(Messages.getString("ECView.UseGeneratorG")); //$NON-NLS-1$
 		btnPGenerator.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) { }
@@ -799,14 +791,15 @@ public class ECContentLarge extends Composite {
 				}
 			}
 		});
+				
 		Label label = new Label(groupP, SWT.NONE);
 		label.setText("x ="); //$NON-NLS-1$
 		txtPX = new Text(groupP, SWT.BORDER | SWT.READ_ONLY);
-		txtPX.setLayoutData(gridData32);
+		txtPX.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		label = new Label(groupP, SWT.NONE);
 		label.setText("y ="); //$NON-NLS-1$
 		txtPY = new Text(groupP, SWT.BORDER | SWT.READ_ONLY);
-		txtPY.setLayoutData(gridData34);
+		txtPY.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 	}
 
 	/**
@@ -814,30 +807,13 @@ public class ECContentLarge extends Composite {
 	 *
 	 */
 	private void createGroupQ() {
-		GridData gridData43 = new GridData();
-		gridData43.horizontalAlignment = org.eclipse.swt.layout.GridData.END;
-		GridData gridData39 = new GridData();
-		gridData39.horizontalSpan = 3;
-		gridData39.grabExcessHorizontalSpace = true;
-		gridData39.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		GridData gridData38 = new GridData();
-		gridData38.horizontalSpan = 2;
-		GridData gridData37 = new GridData();
-		gridData37.grabExcessHorizontalSpace = true;
-		gridData37.horizontalSpan = 3;
-		gridData37.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		GridLayout gridLayout7 = new GridLayout();
-		gridLayout7.numColumns = 4;
-		GridData gridData35 = new GridData();
-		gridData35.grabExcessHorizontalSpace = true;
-		gridData35.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
 		groupQ = new Group(groupCurve, SWT.NONE);
-		groupQ.setLayoutData(gridData35);
-		groupQ.setLayout(gridLayout7);
+		groupQ.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		groupQ.setLayout(new GridLayout(4, false));
 		groupQ.setText(Messages.getString("ECView.Point") + " Q"); //$NON-NLS-1$ //$NON-NLS-2$
 		btnQGenerate = new Button(groupQ, SWT.NONE);
 		btnQGenerate.setText(Messages.getString("ECView.GenerateRandomPoint")); //$NON-NLS-1$
-		btnQGenerate.setLayoutData(gridData38);
+		btnQGenerate.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
 		btnQGenerate.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) { }
 			public void widgetSelected(SelectionEvent e) {
@@ -859,6 +835,7 @@ public class ECContentLarge extends Composite {
 			}
 		});
 		btnQGenerator = new Button(groupQ, SWT.NONE);
+		btnQGenerator.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
 		btnQGenerator.setText(Messages.getString("ECView.UseGeneratorG")); //$NON-NLS-1$
 		btnQGenerator.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {}
@@ -879,48 +856,33 @@ public class ECContentLarge extends Composite {
 		Label label = new Label(groupQ, SWT.NONE);
 		label.setText("x ="); //$NON-NLS-1$
 		txtQX = new Text(groupQ, SWT.BORDER | SWT.READ_ONLY);
-		txtQX.setLayoutData(gridData37);
+		txtQX.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		label = new Label(groupQ, SWT.NONE);
 		label.setText("y ="); //$NON-NLS-1$
 		txtQY = new Text(groupQ, SWT.BORDER | SWT.READ_ONLY);
-		txtQY.setLayoutData(gridData39);
+		txtQY.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 	}
 
 	/**
 	 * This method initializes groupR
 	 *
 	 */
-	private void createGroupR() {
-		GridData gridData42 = new GridData();
-		gridData42.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData42.grabExcessHorizontalSpace = true;
-		GridData gridData41 = new GridData();
-		gridData41.grabExcessHorizontalSpace = true;
-		gridData41.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		GridLayout gridLayout9 = new GridLayout();
-		gridLayout9.numColumns = 2;
-		GridData gridData40 = new GridData();
-		gridData40.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData40.horizontalSpan = 2;
-		gridData40.grabExcessHorizontalSpace = true;
-		GridData gridData36 = new GridData();
-		gridData36.horizontalAlignment = org.eclipse.swt.layout.GridData.FILL;
-		gridData36.grabExcessHorizontalSpace = true;
+	private void createGroupR() {	
 		groupR = new Group(groupCurve, SWT.NONE);
-		groupR.setLayoutData(gridData36);
-		groupR.setLayout(gridLayout9);
+		groupR.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		groupR.setLayout(new GridLayout(2, false));
 		groupR.setText(Messages.getString("ECView.Point") + " R"); //$NON-NLS-1$ //$NON-NLS-2$
 		lblR = new Label(groupR, SWT.NONE);
 		lblR.setText(""); //$NON-NLS-1$
-		lblR.setLayoutData(gridData40);
+		lblR.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
 		Label label = new Label(groupR, SWT.NONE);
 		label.setText("x ="); //$NON-NLS-1$
 		txtRX = new Text(groupR, SWT.BORDER | SWT.READ_ONLY);
-		txtRX.setLayoutData(gridData41);
+		txtRX.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		label = new Label(groupR, SWT.NONE);
 		label.setText("y ="); //$NON-NLS-1$
 		txtRY = new Text(groupR, SWT.BORDER | SWT.READ_ONLY);
-		txtRY.setLayoutData(gridData42);
+		txtRY.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 	}
 
 	/**

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
@@ -111,7 +111,7 @@ public class ECContentLarge extends Composite {
 	private Button btnSave = null;
 	private Label lblP = null;
 	private Composite content;
-    private ScrolledComposite scrolledCompositeSettings;
+//    private ScrolledComposite scrolledCompositeSettings;
 
 	public ECContentLarge(Composite parent, int style, ECView v) {
 		super(parent, style);
@@ -126,7 +126,6 @@ public class ECContentLarge extends Composite {
 
 
 		GridLayout gridLayout = new GridLayout(2, false);
-		gridLayout.verticalSpacing = 2;
 		content.setLayout(gridLayout);
 
 		createCompositeIntro();
@@ -134,7 +133,7 @@ public class ECContentLarge extends Composite {
 		createGroupSettings();
 
 		scrolledComposite.setContent(content);
-		scrolledComposite.setMinSize(content.computeSize(862, 804));
+		scrolledComposite.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
 		fillCSelection();
 		updateScreen();
@@ -198,17 +197,10 @@ public class ECContentLarge extends Composite {
 	 *
 	 */
 	private void createGroupSettings() {
-    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
-    	scrolledCompositeSettings.setExpandVertical(true);
-    	scrolledCompositeSettings.setExpandHorizontal(true);
-    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
-    	scrolledCompositeSettings.setLayout(new GridLayout());
-    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
-    	
-    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+		groupSettings = new Group(content, SWT.NONE);
         groupSettings.setText(Messages.getString("ECView.Settings")); //$NON-NLS-1$
         groupSettings.setLayout(new GridLayout());
-        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
         
 		createGroupSize();
 		createGroupType();
@@ -216,9 +208,6 @@ public class ECContentLarge extends Composite {
 		createGroupRadix();
 		createGroupCalculations();
 		createGroupSave();
-		
-        scrolledCompositeSettings.setContent(groupSettings);
-        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**
@@ -429,7 +418,7 @@ public class ECContentLarge extends Composite {
 		groupCurve = new Group(content, SWT.NONE);
 		groupCurve.setLayout(new GridLayout());
 		GridData gd_groupCurve = new GridData(SWT.FILL, SWT.FILL, true, false);
-		gd_groupCurve.minimumWidth = 700;
+		gd_groupCurve.minimumWidth = 600;
 		groupCurve.setLayoutData(gd_groupCurve);
 		createGroupAttributes();
 		groupCurve.setText(Messages.getString("ECView.EllipticCurve")); //$NON-NLS-1$

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -90,7 +90,6 @@ public class ECContentReal extends Composite {
     private Composite content;
     private Group groupSize;
     private Button rbtnSmall;
-    private ScrolledComposite scrolledCompositeSettings;
 
     public ECContentReal(Composite parent, int style, ECView view) {
         super(parent, style);
@@ -112,7 +111,7 @@ public class ECContentReal extends Composite {
         createGroupSettings();
 
         scrolledComposite.setContent(content);
-        scrolledComposite.setMinSize(content.computeSize(862, 664));
+        scrolledComposite.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
         createGroupAttributesR();
 
@@ -226,26 +225,16 @@ public class ECContentReal extends Composite {
      *
      */
     private void createGroupSettings() {
-    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
-    	scrolledCompositeSettings.setExpandVertical(true);
-    	scrolledCompositeSettings.setExpandHorizontal(true);
-    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
-    	scrolledCompositeSettings.setLayout(new GridLayout());
-    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
-    	
-    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
+    	groupSettings = new Group(content, SWT.NONE);
         groupSettings.setText(Messages.getString("ECContentReal.9")); //$NON-NLS-1$
         groupSettings.setLayout(new GridLayout());
-        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
         
         createGroupSize();
         createGroupCurveType();
         createGroupCurveAttributes();
         createGroupCalculations();
         createGroupSave();
-        
-        scrolledCompositeSettings.setContent(groupSettings);
-        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
     }
 
     /**

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -90,6 +90,7 @@ public class ECContentReal extends Composite {
     private Composite content;
     private Group groupSize;
     private Button rbtnSmall;
+    private ScrolledComposite scrolledCompositeSettings;
 
     public ECContentReal(Composite parent, int style, ECView view) {
         super(parent, style);
@@ -104,7 +105,6 @@ public class ECContentReal extends Composite {
         content = new Composite(scrolledComposite, SWT.NONE);
 
         GridLayout gridLayout = new GridLayout(2, false);
-        gridLayout.verticalSpacing = 2;
         content.setLayout(gridLayout);
 
         createCompositeIntro();
@@ -226,18 +226,26 @@ public class ECContentReal extends Composite {
      *
      */
     private void createGroupSettings() {
-        groupSettings = new Group(content, SWT.NONE);
+    	scrolledCompositeSettings = new ScrolledComposite(content, SWT.V_SCROLL);
+    	scrolledCompositeSettings.setExpandVertical(true);
+    	scrolledCompositeSettings.setExpandHorizontal(true);
+    	scrolledCompositeSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
+    	scrolledCompositeSettings.setLayout(new GridLayout());
+    	scrolledCompositeSettings.setAlwaysShowScrollBars(true);
+    	
+    	groupSettings = new Group(scrolledCompositeSettings, SWT.NONE);
         groupSettings.setText(Messages.getString("ECContentReal.9")); //$NON-NLS-1$
-        groupSettings.setLayout(new GridLayout(1, false));
-        groupSettings.setLayout(new GridLayout(1, false));
-        GridData gridData = new GridData(SWT.FILL, SWT.FILL, false, true);
-        gridData.widthHint = 300;
-        groupSettings.setLayoutData(gridData);
+        groupSettings.setLayout(new GridLayout());
+        groupSettings.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        
         createGroupSize();
         createGroupCurveType();
         createGroupCurveAttributes();
         createGroupCalculations();
         createGroupSave();
+        
+        scrolledCompositeSettings.setContent(groupSettings);
+        scrolledCompositeSettings.setMinSize(groupSettings.computeSize(SWT.DEFAULT, SWT.DEFAULT));
     }
 
     /**
@@ -248,10 +256,7 @@ public class ECContentReal extends Composite {
         canvasCurve = new Canvas(groupCurve, SWT.DOUBLE_BUFFERED);
         canvasCurve.setBackground(white);
         GridData gridData = new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1);
-        // gridData.heightHint = 500;
-        // gridData.widthHint = 500;
         canvasCurve.setLayoutData(gridData);
-        // canvasCurve.setSize(500,500);
         canvasCurve.addPaintListener(new PaintListener() {
             public void paintControl(PaintEvent e) {
                 drawGraph(e);
@@ -307,7 +312,7 @@ public class ECContentReal extends Composite {
     private void createGroupSave() {
         groupSave = new Group(groupSettings, SWT.NONE);
         groupSave.setLayout(new GridLayout(2, false));
-        groupSave.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
+        groupSave.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         groupSave.setText(Messages.getString("ECView.SaveResults")); //$NON-NLS-1$
 
         cSaveResults = new Combo(groupSave, SWT.READ_ONLY);
@@ -383,7 +388,7 @@ public class ECContentReal extends Composite {
      */
     private void createGroupCurveType() {
         groupCurveType = new Group(groupSettings, SWT.NONE);
-        groupCurveType.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
+        groupCurveType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         groupCurveType.setLayout(new GridLayout(3, true));
         groupCurveType.setText(Messages.getString("ECView.SelectCurveType")); //$NON-NLS-1$
         rbtnReal = new Button(groupCurveType, SWT.RADIO);
@@ -515,7 +520,7 @@ public class ECContentReal extends Composite {
         label.setBackground(white);
         label.setText(Messages.getString("ECView.Title")); //$NON-NLS-1$
 
-        stDescription = new StyledText(compositeIntro, SWT.READ_ONLY);
+        stDescription = new StyledText(compositeIntro, SWT.READ_ONLY | SWT.WRAP);
         stDescription.setText(Messages.getString("ECView.Description")); //$NON-NLS-1$
         stDescription.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
     }
@@ -528,7 +533,7 @@ public class ECContentReal extends Composite {
         groupCalculations = new Group(groupSettings, SWT.NONE);
         groupCalculations.setText(Messages.getString("ECContentReal.35")); //$NON-NLS-1$
         groupCalculations.setLayout(new GridLayout(3, false));
-        groupCalculations.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        groupCalculations.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));    
 
         Label label = new Label(groupCalculations, SWT.WRAP);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));


### PR DESCRIPTION
I've added a scrollbar to the settings group on the right to keep all possible settings visible. In addition, the width of the setting group adapts to the minimum size of the contained elements.
The elements in the groups point P and point Q are displayed correctly again.
That's how it looked like before.

<img width="795" alt="ecc_bug_1" src="https://user-images.githubusercontent.com/20046726/32992901-e37cfebc-cd50-11e7-9a47-c5852e7ce695.PNG">
<img width="795" alt="ecc_bug_2" src="https://user-images.githubusercontent.com/20046726/32992902-e39b7130-cd50-11e7-9d9b-9f61be79ad6b.PNG">


