### PR TITLE
GUI improvements in Merkle-Hellman Cryptosystem Plugin

### DIFF
--- a/org.jcryptool.visual.merkleHellman/nl/de/help/content/index.html
+++ b/org.jcryptool.visual.merkleHellman/nl/de/help/content/index.html
@@ -71,7 +71,7 @@ Für ggT(M,W) != 1 wird folgender Hinweis angezeigt:
 
 Nachdem nun alle Bedingungen erfüllt sind, wird der öffentliche Schlüssel erzeugt und die Elemente B(i) werden in dem Grundbereich <b>Öffentlicher Schlüssel B</b> angezeigt.
 <p>
-<img src="merkleHellman_pubKey.jpg">
+<img width="700" src="merkleHellman_pubKey.jpg">
 <p>
 
 <a name="Kapitel2"><b>2) Verschlüsselung</b></a>
@@ -79,7 +79,7 @@ Nachdem nun alle Bedingungen erfüllt sind, wird der öffentliche Schlüssel erz
 Nachdem nun die Schlüssel erzeugt sind, kann der Benutzer eine Nachricht <b>m</b> in 
 das entsprechende Feld eingeben. Der Zahlenwert der Nachricht <b>m</b> wird auch im Zweiersystem berechnet und in dem Feld <b>Binärdarstellung von m</b> angezeigt. Der Button <img src="merkleHellman_encrypt.jpg" style="vertical-align:middle"> wird aktiv, sobald ein gültiger Wert <b>m</b> eingegeben wurde.
 <p>
-<img width="700" src="merkleHellman_bin.jpg">
+<img src="merkleHellman_bin.jpg">
 <p>
 
 Beim Klick auf den Button <img src="merkleHellman_encrypt.jpg" style="vertical-align:middle"> werden die Nachrichten-Teile berechnet und die Iterationen der Berechnungen in die darunter liegende Tabelle eingetragen. Der Geheimtext wird ebenfalls berechnet, angezeigt und für die Entschlüsselung übernommen.

--- a/org.jcryptool.visual.merkleHellman/nl/de/help/content/index.html
+++ b/org.jcryptool.visual.merkleHellman/nl/de/help/content/index.html
@@ -27,7 +27,7 @@ Inhaltsübersicht:<br>
 Das Plug-in lässt sich über das Menü <b>Visualisierungen</b> oder über den Krypto-Explorer im Tab <b>Visualisierungen</b> starten.
 <p>
 
-<img src="merkleHellman_main.jpg">
+<img width="700" src="merkleHellman_main.jpg">
 
 <p>
 Das Plug-in besteht aus einem Beschreibungsfeld und drei Grundbereichen: <b>Schlüsselerzeugung</b>, <b>Verschlüsselung</b> und 
@@ -46,7 +46,7 @@ Dieser Bereich fasst die Aktionen zusammen, die zur Erzeugung eines privaten Sch
 <p>
 Zu erst müssen die Anzahl der Elemente für den privaten Schlüssel und der Startwert über die Dropdown-Boxen ausgewählt werden. Standardmäßig hat die Anzahl der Schlüsselelemente den Wert 4 und der Startwert ist 32. Der Startwert wird für die Berechnung des ersten Schlüsselelements A(1) verwendet. Es wird eine Zufallszahl aus dem Bereich [Startwert/2 - Startwert] gewählt. Die Schlüsselelemente werden dann anhand der Benutzer-Eingaben dynamisch erzeugt.
 <p>
-<img src="merkleHellman_key.jpg">
+<img width="700" src="merkleHellman_key.jpg">
 <p>
 
 Der Benutzer kann nun die automatisch und zufällig generierten Beispielwerte für <b>A(i)</b>, <b>M</b> und <b>W</b> verwenden, manuell bearbeiten bzw. verändern oder neue Werte per Klick auf den Button 
@@ -79,7 +79,7 @@ Nachdem nun alle Bedingungen erfüllt sind, wird der öffentliche Schlüssel erz
 Nachdem nun die Schlüssel erzeugt sind, kann der Benutzer eine Nachricht <b>m</b> in 
 das entsprechende Feld eingeben. Der Zahlenwert der Nachricht <b>m</b> wird auch im Zweiersystem berechnet und in dem Feld <b>Binärdarstellung von m</b> angezeigt. Der Button <img src="merkleHellman_encrypt.jpg" style="vertical-align:middle"> wird aktiv, sobald ein gültiger Wert <b>m</b> eingegeben wurde.
 <p>
-<img src="merkleHellman_bin.jpg">
+<img width="700" src="merkleHellman_bin.jpg">
 <p>
 
 Beim Klick auf den Button <img src="merkleHellman_encrypt.jpg" style="vertical-align:middle"> werden die Nachrichten-Teile berechnet und die Iterationen der Berechnungen in die darunter liegende Tabelle eingetragen. Der Geheimtext wird ebenfalls berechnet, angezeigt und für die Entschlüsselung übernommen.

--- a/org.jcryptool.visual.merkleHellman/nl/en/help/content/index.html
+++ b/org.jcryptool.visual.merkleHellman/nl/en/help/content/index.html
@@ -27,7 +27,7 @@ Table of contents:<br>
 The plug-in can be started via the menu <b>Visuals</b> or via the crypto explorer tab <b>Visuals</b>.
 <p>
 
-<img src="merkleHellman_main.jpg">
+<img width="700" src="merkleHellman_main.jpg">
 
 <p>
 The plug-in consists of a description field at the top, and three basic areas below: <b>Key generation</b>, <b>Encryption</b> and <b>Decryption</b>.
@@ -50,7 +50,7 @@ start value is needed for the generation of the first element of the private key
 value]. The number of the private key elements will be dynamically created
 depending on user selection.
 <p>
-<img src="merkleHellman_key.jpg">
+<img width="700" src="merkleHellman_key.jpg">
 <p>
 
 On this selection, the user can either use the automatically and randomly generated sample values for <b>A(i)</b>, <b>M</b> and <b>W</b>, or he can manually enter new values, or he can generate new values for the private key by clicking the button <b>Generate private key</b> <img src="merkleHellman_generatePrivKey.jpg">.
@@ -74,7 +74,7 @@ For ggT(M,W) != 1 the following information is shown:
 
 After all conditions are met the public key will be calculated and the elements B(i) are shown in the <b>Public key B</b> area.
 <p>
-<img src="merkleHellman_pubKey.jpg">
+<img width="700" src="merkleHellman_pubKey.jpg">
 <p>
 
 <a name="Kapitel2"><b>2) Encryption</b></a> 

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
@@ -15,7 +15,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.VerifyEvent;
 import org.eclipse.swt.events.VerifyListener;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -169,16 +168,11 @@ public class MerkleHellmanView extends ViewPart {
 
 		Composite compositeMain = new Composite(scrolledComposite, SWT.NONE);
 		compositeMain.setLayout(new GridLayout(2, false));
-
+		
 		styledTextDescription = new StyledText(compositeMain, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP);
 		styledTextDescription.setEditable(false);
 		GridData gd_styledTextDescription = new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1);
-		gd_styledTextDescription.widthHint = 300;
-		if (System.getProperty("os.name").compareToIgnoreCase("Windows 8") == 0) {
-			gd_styledTextDescription.heightHint = 80;
-		} else {
-			gd_styledTextDescription.heightHint = 60;			
-		}
+		gd_styledTextDescription.widthHint = 400;
 		styledTextDescription.setLayoutData(gd_styledTextDescription);
 		styledTextDescription.setText(Messages.MerkleHellmanView_0000 + Messages.MerkleHellmanView_0);
 
@@ -238,7 +232,6 @@ public class MerkleHellmanView extends ViewPart {
 
 		btnGenerateNewKey = new Button(compositeSelection, SWT.NONE);
 		GridData gd_btnGenerateNewKey = new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1);
-		gd_btnGenerateNewKey.widthHint = 200;
 		
 		if (System.getProperty("os.name").compareToIgnoreCase("Windows 8") == 0) {
 			gd_btnGenerateNewKey.widthHint = 220;						
@@ -934,11 +927,7 @@ public class MerkleHellmanView extends ViewPart {
 		btnDecrypt.setLayoutData(gd_btnDecrypt);
 		btnDecrypt.setText(Messages.MerkleHellmanView_17);
 		scrolledComposite.setContent(compositeMain);
-		if (System.getProperty("os.name").compareToIgnoreCase("Windows 8") == 0) {
-			scrolledComposite.setMinSize(new Point(1310, 566));
-		} else {
-			scrolledComposite.setMinSize(new Point(1010, 566));			
-		}
+		scrolledComposite.setMinSize(compositeMain.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 		int numberOfElements = Integer.parseInt(comboKeyElements.getText());
 		int startValue = Integer.parseInt(comboStartValue.getText());
 

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
@@ -231,15 +231,7 @@ public class MerkleHellmanView extends ViewPart {
 		comboStartValue.select(0);
 
 		btnGenerateNewKey = new Button(compositeSelection, SWT.NONE);
-		GridData gd_btnGenerateNewKey = new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1);
-		
-		if (System.getProperty("os.name").compareToIgnoreCase("Windows 8") == 0) {
-			gd_btnGenerateNewKey.widthHint = 220;						
-		} else {
-			gd_btnGenerateNewKey.widthHint = 180;			
-		}
-		
-		btnGenerateNewKey.setLayoutData(gd_btnGenerateNewKey);
+		btnGenerateNewKey.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1));
 		btnGenerateNewKey.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -468,14 +460,7 @@ public class MerkleHellmanView extends ViewPart {
 				}
 			}
 		});
-		GridData gd_btnCreateKeys = new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1);
-		gd_btnCreateKeys.widthHint = 200;
-		if (System.getProperty("os.name").compareToIgnoreCase("Windows 8") == 0) {
-			gd_btnCreateKeys.widthHint = 220;
-		} else {
-			gd_btnCreateKeys.widthHint = 180;
-		}
-		btnCreateKeys.setLayoutData(gd_btnCreateKeys);
+		btnCreateKeys.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		btnCreateKeys.setText(Messages.MerkleHellmanView_7);
 
 		Group grpPublicKey = new Group(grpGroup, SWT.NONE);


### PR DESCRIPTION
A small PR for the Merkle-Hellman Cryptosystem Plugin.
The description text got cut off and the buttons for generate private key and generate public key got also cut off in the german version.
<img width="663" alt="old_main" src="https://user-images.githubusercontent.com/20046726/34641208-ce21dddc-f300-11e7-8259-de434b966995.PNG">
<img width="775" alt="new_main" src="https://user-images.githubusercontent.com/20046726/34641209-cf030438-f300-11e7-9a9d-07485d109a1f.PNG">
The scrolling behaviour is improved. I removed the static layout data that specified the window size.
It looks like this now:
<img width="686" alt="scrolling_new" src="https://user-images.githubusercontent.com/20046726/34641230-2365dfe6-f301-11e7-9fab-4a041932d891.PNG">

In the online help i added width's to the larger images, so that a scrollbar isn't necessary to show it properly.
It changed from this:
<img width="789" alt="onlinehelp_old" src="https://user-images.githubusercontent.com/20046726/34641258-8bd1d6b6-f301-11e7-986d-a616c52976f0.PNG">
to this:
<img width="834" alt="onlinehelp_new" src="https://user-images.githubusercontent.com/20046726/34641260-90597b94-f301-11e7-8e49-d11c5df27c2b.PNG">




References #117  