### PR TITLE
Public Key Infrastructure GUI improvements

### DIFF
--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
@@ -50,10 +50,11 @@ public class JCTCA_Visual extends ViewPart {
     private Composite comp_center;
     private TabFolder tabFolder;
     private StyledText stl_explain;
+    private ScrolledComposite root;
 
     @Override
     public void createPartControl(Composite parent) {
-        ScrolledComposite root = new ScrolledComposite(parent, SWT.BORDER);
+        root = new ScrolledComposite(parent, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
         composite = new Composite(root, SWT.NONE);
         root.setContent(composite);
         root.setExpandHorizontal(true);
@@ -74,7 +75,9 @@ public class JCTCA_Visual extends ViewPart {
         // Set the headline text to the title of the plugin
         headline.setText(Messages.JCTCA_Visual_Plugin_Headline);
         head_description = new StyledText(head_composite, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP);
-        head_description.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
+        GridData gd_head_description = new GridData(SWT.FILL, SWT.NONE, true, false);
+        gd_head_description.widthHint = 700;
+        head_description.setLayoutData(gd_head_description);
         // set the short introduction text for the certificate creation picture
         // because this is the first text that needs to be shown
         head_description.setText(Messages.JCTCA_Visual_archpic_create_text);
@@ -135,6 +138,8 @@ public class JCTCA_Visual extends ViewPart {
         btn_continue.setData(new Integer(3));
         btn_continue.addSelectionListener(new PluginBtnListener(this, lbl_img, head_description));
         composite.layout(true);
+        
+        root.setMinSize(composite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
     }
 
     public void showCenter() {
@@ -144,50 +149,43 @@ public class JCTCA_Visual extends ViewPart {
         comp_center.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
         tabFolder = new TabFolder(comp_center, SWT.NONE);
-        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
+        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
         Group grp_explain = new Group(comp_center, SWT.NONE);
         grp_explain.setLayout(new GridLayout(1, true));
-        GridData gd_explain = new GridData(SWT.FILL, SWT.FILL, true, true);
-        // gd_explain.minimumWidth = 150;
-        // gd_explain.widthHint = 10;
-
+        GridData gd_explain = new GridData(SWT.FILL, SWT.FILL, false, true);
+        gd_explain.widthHint = 500;
         grp_explain.setLayoutData(gd_explain);
         grp_explain.setText(Messages.JCTCA_Visual_grp_explain_headline);
 
-        // scrolled composite for vertical scrollbar
-        ScrolledComposite scrolled_comp = new ScrolledComposite(grp_explain, SWT.V_SCROLL);
-        scrolled_comp.setLayout(new GridLayout(1, true));
-        scrolled_comp.setLayoutData(gd_explain);
-        scrolled_comp.setExpandVertical(true);
-        scrolled_comp.setExpandHorizontal(true);
-
-        Composite comp_vscroll = new Composite(scrolled_comp, SWT.FILL);
-        comp_vscroll.setLayout(new GridLayout(1, true));
-        scrolled_comp.setContent(comp_vscroll);
-
-        comp_vscroll.setLayoutData(gd_explain);
-        comp_vscroll.setSize(comp_vscroll.computeSize(SWT.DEFAULT, SWT.DEFAULT));
-
         // label for showing explanation texts
-        stl_explain = new StyledText(comp_vscroll, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
+        stl_explain = new StyledText(grp_explain, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
         GridData gd_txt_explain = new GridData(SWT.FILL, SWT.FILL, true, true);
         stl_explain.setLayoutData(gd_txt_explain);
 
-        TabItemListener tabItemListener = new TabItemListener(tabFolder, comp_vscroll);
+        TabItemListener tabItemListener = new TabItemListener(tabFolder, grp_explain);
         tabFolder.addSelectionListener(tabItemListener);
 
-        @SuppressWarnings("unused")
-        UserTab user = new UserTab(tabFolder, comp_vscroll, SWT.NONE);
-        @SuppressWarnings("unused")
-        RegistrationTab ra = new RegistrationTab(tabFolder, comp_vscroll, SWT.NONE);
-        @SuppressWarnings("unused")
-        CertificationTab ca = new CertificationTab(tabFolder, comp_vscroll, SWT.NONE);
-        @SuppressWarnings("unused")
-        SecondUserTab scndUser = new SecondUserTab(tabFolder, comp_vscroll, SWT.NONE);
+//        @SuppressWarnings("unused")
+//        UserTab user = new UserTab(tabFolder, comp_vscroll, SWT.NONE);
+//        new UserTab(tabFolder, comp_vscroll, SWT.NONE);
+        new UserTab(tabFolder, grp_explain, SWT.NONE);
+//        @SuppressWarnings("unused")
+//        RegistrationTab ra = new RegistrationTab(tabFolder, comp_vscroll, SWT.NONE);
+//        new RegistrationTab(tabFolder, comp_vscroll, SWT.NONE);
+        new RegistrationTab(tabFolder, grp_explain, SWT.NONE);
+//        @SuppressWarnings("unused")
+//        CertificationTab ca = new CertificationTab(tabFolder, comp_vscroll, SWT.NONE);
+//        new CertificationTab(tabFolder, comp_vscroll, SWT.NONE);
+        new CertificationTab(tabFolder, grp_explain, SWT.NONE);
+//        @SuppressWarnings("unused")
+//        SecondUserTab scndUser = new SecondUserTab(tabFolder, comp_vscroll, SWT.NONE);
+//        new SecondUserTab(tabFolder, comp_vscroll, SWT.NONE);
+        new SecondUserTab(tabFolder, grp_explain, SWT.NONE);
 
         tabFolder.setSelection(0);
-        composite.layout(true, true);
+        composite.layout();
+        
     }
 
     public void disposeCompCenter() {
@@ -196,5 +194,6 @@ public class JCTCA_Visual extends ViewPart {
 
     @Override
     public void setFocus() {
+    	composite.setFocus();
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
@@ -166,21 +166,12 @@ public class JCTCA_Visual extends ViewPart {
         TabItemListener tabItemListener = new TabItemListener(tabFolder, grp_explain);
         tabFolder.addSelectionListener(tabItemListener);
 
-//        @SuppressWarnings("unused")
-//        UserTab user = new UserTab(tabFolder, comp_vscroll, SWT.NONE);
-//        new UserTab(tabFolder, comp_vscroll, SWT.NONE);
         new UserTab(tabFolder, grp_explain, SWT.NONE);
-//        @SuppressWarnings("unused")
-//        RegistrationTab ra = new RegistrationTab(tabFolder, comp_vscroll, SWT.NONE);
-//        new RegistrationTab(tabFolder, comp_vscroll, SWT.NONE);
+
         new RegistrationTab(tabFolder, grp_explain, SWT.NONE);
-//        @SuppressWarnings("unused")
-//        CertificationTab ca = new CertificationTab(tabFolder, comp_vscroll, SWT.NONE);
-//        new CertificationTab(tabFolder, comp_vscroll, SWT.NONE);
+        
         new CertificationTab(tabFolder, grp_explain, SWT.NONE);
-//        @SuppressWarnings("unused")
-//        SecondUserTab scndUser = new SecondUserTab(tabFolder, comp_vscroll, SWT.NONE);
-//        new SecondUserTab(tabFolder, comp_vscroll, SWT.NONE);
+
         new SecondUserTab(tabFolder, grp_explain, SWT.NONE);
 
         tabFolder.setSelection(0);

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
@@ -14,12 +14,15 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -46,6 +49,7 @@ public class JCTCA_Visual extends ViewPart {
     private static final Color WHITE = Display.getDefault().getSystemColor(SWT.COLOR_WHITE);
 
     private Composite composite;
+    private Composite head_composite;
     private StyledText head_description;
     private Composite comp_center;
     private TabFolder tabFolder;
@@ -60,11 +64,10 @@ public class JCTCA_Visual extends ViewPart {
         root.setExpandHorizontal(true);
         root.setExpandVertical(true);
 
-        GridLayout gl = new GridLayout(1, false);
-        composite.setLayout(gl);
+        composite.setLayout(new GridLayout(1, false));
 
         // Begin - headline area
-        Composite head_composite = new Composite(composite, SWT.NONE);
+        head_composite = new Composite(composite, SWT.NONE);
         head_composite.setBackground(WHITE);
         head_composite.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
         head_composite.setLayout(new GridLayout());
@@ -75,12 +78,20 @@ public class JCTCA_Visual extends ViewPart {
         // Set the headline text to the title of the plugin
         headline.setText(Messages.JCTCA_Visual_Plugin_Headline);
         head_description = new StyledText(head_composite, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP);
-        GridData gd_head_description = new GridData(SWT.FILL, SWT.NONE, true, false);
+        GridData gd_head_description = new GridData(SWT.FILL, SWT.FILL, true, false);
         gd_head_description.widthHint = 700;
         head_description.setLayoutData(gd_head_description);
         // set the short introduction text for the certificate creation picture
         // because this is the first text that needs to be shown
         head_description.setText(Messages.JCTCA_Visual_archpic_create_text);
+        head_description.addModifyListener(new ModifyListener() {
+			
+			@Override
+			public void modifyText(ModifyEvent e) {
+				//Resize the control when the text changes
+				parent.layout(new Control[] {head_description});
+			}
+		});
         // End - Header
         showArchitecture();
 
@@ -143,6 +154,7 @@ public class JCTCA_Visual extends ViewPart {
     }
 
     public void showCenter() {
+    	
         comp_center = new Composite(composite, SWT.NONE);
         // 2 columns (tabs and explanation) --> new GridLayout(2, false);
         comp_center.setLayout(new GridLayout(2, false));
@@ -175,7 +187,9 @@ public class JCTCA_Visual extends ViewPart {
         new SecondUserTab(tabFolder, grp_explain, SWT.NONE);
 
         tabFolder.setSelection(0);
-        composite.layout();
+        composite.layout(true);
+        
+        root.setMinSize(composite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         
     }
 

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
@@ -199,6 +199,6 @@ public class JCTCA_Visual extends ViewPart {
 
     @Override
     public void setFocus() {
-    	composite.setFocus();
+    	root.setFocus();
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
@@ -31,10 +31,12 @@ import org.jcryptool.visual.jctca.listeners.CSRListener;
  * 
  */
 public class ShowCSR implements Views {
+	
     private List lst_csr;
+    private Group showCSRGroup;
      
     public ShowCSR(Composite content, Composite exp) {
-        Group showCSRGroup = new Group(content, SWT.NONE);
+        showCSRGroup = new Group(content, SWT.NONE);
         showCSRGroup.setLayout(new GridLayout(3, false));
         GridData gd_grp = new GridData(SWT.FILL, SWT.FILL, true, true);
         showCSRGroup.setLayoutData(gd_grp);
@@ -144,9 +146,11 @@ public class ShowCSR implements Views {
 
     @Override
     public void dispose() {
+    	showCSRGroup.dispose();
     }
 
     @Override
     public void setVisible(boolean visible) {
+    	showCSRGroup.setVisible(visible);
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
@@ -45,6 +45,7 @@ public class ShowCSR implements Views {
         Composite left = new Composite(showCSRGroup, SWT.NONE);
         left.setLayout(new GridLayout(1, true));
         left.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        
         Composite center = new Composite(showCSRGroup, SWT.NONE);
         center.setLayout(new GridLayout(2, false));
         center.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/ShowSigData.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/ShowSigData.java
@@ -61,16 +61,16 @@ public class ShowSigData implements Views {
         lbl_signature.setLayoutData(gd_txt);
 
         Button btn_get_CRL = new Button(showSelectedRequest, SWT.CHECK);
-        btn_get_CRL.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_get_CRL.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_get_CRL.setText(Messages.ShowSigData_checkbox_check_revoke_status);
 
         Button btn_check_signature = new Button(showSelectedRequest, SWT.NONE);
-        btn_check_signature.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_check_signature.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_check_signature.setText(Messages.ShowSigData_btn_check_sig);
         btn_check_signature.setEnabled(false);
 
         Button btn_deleteEntry = new Button(showSelectedRequest, SWT.NONE);
-        btn_deleteEntry.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_deleteEntry.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_deleteEntry.setText(Messages.ShowSigData_btn_delete_entry);
         btn_deleteEntry.setEnabled(false);
         SecondUserListener listener = new SecondUserListener(btn_check_signature, btn_get_CRL, tree, lbl_text,

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/CreateCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/CreateCert.java
@@ -39,76 +39,77 @@ public class CreateCert implements Views {
     public CreateCert(Composite content, Composite exp) {
         composite = new Composite(content, SWT.NONE);
         composite.setLayout(new GridLayout(1, true));
-        composite.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, true));
+        composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
         Group createCertGroup = new Group(composite, SWT.NONE);
         createCertGroup.setLayout(new GridLayout(2, false));
-        GridData gd_grp = new GridData(SWT.FILL, SWT.NONE, true, true);
-        createCertGroup.setLayoutData(gd_grp);
+        createCertGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         createCertGroup.setText(Messages.CreateCert_headline);
 
         Label lbl_firstname = new Label(createCertGroup, SWT.NONE);
         lbl_firstname.setText(Messages.CreateCert_lbl_first_name);
         Text txt_firstname = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_firstname.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_firstname.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_firstname.setText(Messages.CreateCert_sample_first_name);
 
         Label lbl_lastname = new Label(createCertGroup, SWT.None);
         lbl_lastname.setText(Messages.CreateCert_lbl_last_name);
         Text txt_lastname = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_lastname.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_lastname.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_lastname.setText(Messages.CreateCert_sample_last_name);
 
         Label lbl_street = new Label(createCertGroup, SWT.None);
         lbl_street.setText(Messages.CreateCert_lbl_street);
         Text txt_street = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_street.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_street.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_street.setText(Messages.CreateCert_sample_street);
 
         Label lbl_ZIP = new Label(createCertGroup, SWT.None);
         lbl_ZIP.setText(Messages.CreateCert_lbl_zip);
         Text txt_ZIP = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_ZIP.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_ZIP.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_ZIP.setText(Messages.CreateCert_sample_zip);
 
         Label lbl_city = new Label(createCertGroup, SWT.None);
         lbl_city.setText(Messages.CreateCert_lbl_city);
         Text txt_city = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_city.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_city.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_city.setText(Messages.CreateCert_sample_city);
 
         Label lbl_country = new Label(createCertGroup, SWT.None);
         lbl_country.setText(Messages.CreateCert_lbl_country);
         Text txt_country = new Text(createCertGroup, SWT.SINGLE | SWT.BORDER);
-        txt_country.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_country.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_country.setText(Messages.CreateCert_sample_country);
 
         Label lbl_mail = new Label(createCertGroup, SWT.None);
         lbl_mail.setText(Messages.CreateCert_lbl_mail);
         Text txt_mail = new Text(createCertGroup, SWT.BORDER | SWT.SINGLE);
-        txt_mail.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        txt_mail.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         txt_mail.setText(Messages.CreateCert_sample_mail);
+        
         Label lbl_proof = new Label(createCertGroup, SWT.None);
         lbl_proof.setText(Messages.CreateCert_lbl_idproof);
         Button btn_proof = new Button(createCertGroup, SWT.None);
         btn_proof.setText(Messages.CreateCert_btn_select_file);
-        btn_proof.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_proof.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_proof.setData(new Integer(0));
 
         Label lbl_pubKey = new Label(createCertGroup, SWT.NONE);
         lbl_pubKey.setText(Messages.CreateCert_public_key);
+        lbl_pubKey.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false, 1, 3));
 
         Button btn_radio_selectPubKey = new Button(createCertGroup, SWT.RADIO);
         btn_radio_selectPubKey.setText(Messages.CreateCert_radio_btn_sel_pubkey);
         btn_radio_selectPubKey.setData("select"); //$NON-NLS-1$
-        new Label(createCertGroup, SWT.NONE);
+        
         GridData gd_cmb = new GridData(GridData.FILL_HORIZONTAL);
         gd_cmb.horizontalIndent = 26;
+        gd_cmb.widthHint = 200;
         cmb_genKey = new Combo(createCertGroup, SWT.NONE);
         cmb_genKey.setEnabled(false);
         cmb_genKey.setLayoutData(gd_cmb);
 
-        new Label(createCertGroup, SWT.NONE);
         Button btn_radio_generatePubKey = new Button(createCertGroup, SWT.RADIO);
         btn_radio_generatePubKey.setText(Messages.CreateCert_radio_btn_gen_pubkey);
         btn_radio_generatePubKey.setData("generate"); //$NON-NLS-1$
@@ -126,7 +127,7 @@ public class CreateCert implements Views {
         Button btn_send = new Button(composite, SWT.NONE);
         btn_send.setText(Messages.CreateCert_btn_send_csr_to_ra);
         btn_send.addSelectionListener(lst);
-        btn_send.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
+        btn_send.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false));
         btn_send.setData(2);
 
         StyledText stl_exp = (StyledText) exp.getChildren()[0];

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/ShowCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/ShowCert.java
@@ -46,7 +46,7 @@ public class ShowCert implements Views {
     public ShowCert(Composite content, Composite exp) {
         composite = new Composite(content, SWT.NONE);
         composite.setLayout(new GridLayout(2, false));
-        GridData gd_comp = new GridData(SWT.FILL, SWT.TOP, true, true);
+        GridData gd_comp = new GridData(SWT.FILL, SWT.FILL, true, true);
         composite.setLayoutData(gd_comp);
 
         Group showCertGroup = new Group(composite, SWT.NONE);

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/SignCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/SignCert.java
@@ -34,14 +34,14 @@ public class SignCert implements Views {
     private Combo cmb_priv_key;
 
     public SignCert(Composite content, Composite exp) {
-        this.composite = new Composite(content, SWT.NONE);
-        this.composite.setLayout(new GridLayout(1, false));
-        GridData gd_comp = new GridData(SWT.FILL, SWT.FILL, true, false);
+        composite = new Composite(content, SWT.NONE);
+        composite.setLayout(new GridLayout(1, false));
+        GridData gd_comp = new GridData(SWT.FILL, SWT.FILL, true, true);
         composite.setLayoutData(gd_comp);
 
         Group cmp_mini = new Group(composite, SWT.NONE);
-        cmp_mini.setLayout(new GridLayout(2, false));
-        cmp_mini.setLayoutData(gd_comp);
+        cmp_mini.setLayout(new GridLayout());
+        cmp_mini.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         cmp_mini.setText(Messages.SignCert_chose_method);
 
         Group selectSthGroup = new Group(composite, SWT.None);
@@ -51,7 +51,7 @@ public class SignCert implements Views {
 
         Group signCertGroup = new Group(composite, SWT.NONE);
         signCertGroup.setLayout(new GridLayout(1, false));
-        signCertGroup.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
+        signCertGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         signCertGroup.setText(Messages.SignCert_headline);
 
         Composite signBtnComp = new Composite(composite, SWT.NONE);
@@ -60,32 +60,26 @@ public class SignCert implements Views {
 
         Composite selectSthComp = new Composite(selectSthGroup, SWT.NONE);
         selectSthComp.setLayout(new GridLayout(3, false));
-        selectSthComp.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL));
+        selectSthComp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
         Button btn_detail = new Button(cmp_mini, SWT.RADIO);
+        btn_detail.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_detail.setText(Messages.SignCert_checkbox_show_sigvis);
         btn_detail.setData("detail"); //$NON-NLS-1$
         btn_detail.setSelection(true);
 
         Button btn_non_detail = new Button(cmp_mini, SWT.RADIO);
+        btn_non_detail.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         btn_non_detail.setText(Messages.SignCert_sign_directly);
         btn_non_detail.setData("detail"); //$NON-NLS-1$
 
-        Composite cmp_minimi = new Composite(cmp_mini, SWT.NONE);
-        cmp_minimi.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 2, 1));
-        cmp_minimi.setLayout(new GridLayout(2, false));
-
-        Label filler = new Label(cmp_minimi, SWT.None);
-        filler.setText(""); //$NON-NLS-1$
-        GridData gd = new GridData();
-        gd.widthHint = 7;
-        filler.setLayoutData(gd);
-
-        Label lbl_detail = new Label(cmp_minimi, SWT.WRAP);
+        Label lbl_detail = new Label(cmp_mini, SWT.WRAP);
         lbl_detail.setText(Messages.SignCert_footnote_input_in_signvis);
         lbl_detail.setForeground(dark_gray);
-        lbl_detail.setLayoutData(new GridData(SWT.NONE, SWT.NONE, false, false, 1, 1));
-
+        GridData gd_lbl_detail = new GridData(SWT.FILL, SWT.FILL, true, false);
+        gd_lbl_detail.widthHint = 300;
+        lbl_detail.setLayoutData(gd_lbl_detail);
+        
         Button btn_radio_signFile = new Button(selectSthComp, SWT.RADIO);
         btn_radio_signFile.setText(Messages.SignCert_file);
         btn_radio_signFile.setData("file"); //$NON-NLS-1$
@@ -125,12 +119,12 @@ public class SignCert implements Views {
                 btn_select_file, selected_file, txt_sign, btn_select_file));
 
         cmb_priv_key = new Combo(signCertGroup, SWT.DROP_DOWN);
-        cmb_priv_key.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false, 1, 1));
+        cmb_priv_key.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
         addRSAPrivateKeysToDropdown();
         cmb_priv_key.select(0);
 
         Button btn_sign = new Button(signBtnComp, SWT.PUSH);
-        btn_sign.setLayoutData(gd_comp);
+        btn_sign.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
         btn_sign.setText(Messages.SignCert_btn_sign_with_key);
         btn_sign.addSelectionListener(new SigVisPluginOpenListener(btn_detail, selected_file, txt_sign, cmb_priv_key));
 

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
@@ -10,6 +10,8 @@
 //-----END DISCLAIMER-----
 package org.jcryptool.visual.jctca.listeners;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
@@ -75,6 +77,8 @@ public class SideBarListener implements SelectionListener {
         }
         // layout the composite afterwards. also changes the explain group
         comp_right.layout(true, true);
+        ScrolledComposite sc1 = (ScrolledComposite) comp_right.getParent().getParent();
+        sc1.setMinSize(comp_right.getParent().computeSize(SWT.DEFAULT, SWT.DEFAULT));
         grp_exp.layout(true);
         
 //        comp_right.getParent().getParent()

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
@@ -76,6 +76,9 @@ public class SideBarListener implements SelectionListener {
         // layout the composite afterwards. also changes the explain group
         comp_right.layout(true, true);
         grp_exp.layout(true);
+        
+//        comp_right.getParent().getParent()
+        
     }
 
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/TabItemListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/TabItemListener.java
@@ -13,6 +13,7 @@ package org.jcryptool.visual.jctca.listeners;
 import java.util.ArrayList;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -58,18 +59,32 @@ public class TabItemListener implements SelectionListener {
             stl_exp.setText(Messages.TabItemListener_tab_user_explain);
             Control[] x = (parent.getChildren());
             if (x.length > 0) {
-                Control[] foo = ((Group) x[0]).getChildren();
-                Composite right = (Composite) foo[1];
+            	ScrolledComposite sc1 = (ScrolledComposite) parent.getChildren()[0];
+//            	Group g1 = (Group) sc1.getChildren()[0];
+            	Group g1 = (Group) sc1.getContent();
+//                Control[] foo = ((Group) x[0]).getChildren();
+//                Composite right = (Composite) foo[1];
+//            	Composite right = (Composite) g1.getChildren()[0];
+            	// If it schould be Composite right from UserTab it has to be g1.getChildren()[1]
+            	Composite right = (Composite) g1.getChildren()[1];
                 if (right.getChildren().length > 0) {
                     Composite right2 = (Composite) right.getChildren()[0];
                     right2.dispose();
-                    ((Group) x[0]).layout(true);
+//                    ((Group) x[0]).layout(true);
+//                    sc1.layout(true);
+//                    parent.layout();
+//                    g1.layout();
+//                    g1.redraw();
+                    g1.layout(true);
                 }
+//                sc1.layout();
+//                g1.layout(true);
             }
         } else if (parent.getSelectionIndex() == 1) {
             // RA View, fills up the list with CSRs
             stl_exp.setText(Messages.TabItemListener_tab_ra_explain);
-            Group g1 = (Group) parent.getChildren()[1];
+            ScrolledComposite sc1 = (ScrolledComposite) parent.getChildren()[1];
+            Group g1 = (Group) sc1.getChildren()[0];
             Group g2 = (Group) g1.getChildren()[0];
             Composite c = (Composite) g2.getChildren()[0];
             List lst_csr = (List) c.getChildren()[0];
@@ -84,7 +99,8 @@ public class TabItemListener implements SelectionListener {
         } else if (parent.getSelectionIndex() == 2) {
             // CA View, fills up the tree with CSRs and RRs
             stl_exp.setText(Messages.TabItemListener_tab_ca_explain);
-            Group g1 = (Group) parent.getChildren()[2];
+            ScrolledComposite sc1 = (ScrolledComposite) parent.getChildren()[2];
+            Group g1 = (Group) sc1.getChildren()[0];
             Composite c = (Composite) g1.getChildren()[0];
             Composite c1 = (Composite) c.getChildren()[0];
             Tree tree = (Tree) c1.getChildren()[0];
@@ -111,7 +127,8 @@ public class TabItemListener implements SelectionListener {
         } else if (parent.getSelectionIndex() == 3) {
             // 2nd User View, fills up the tree with the signatures
             stl_exp.setText(Messages.TabItemListener_tab_secuser_explain);
-            Group g1 = (Group) parent.getChildren()[3];
+            ScrolledComposite sc1 = (ScrolledComposite) parent.getChildren()[3];
+            Group g1 = (Group) sc1.getChildren()[0];
             Composite c = (Composite) g1.getChildren()[0];
             Composite c1 = (Composite) c.getChildren()[0];
             Tree tree = (Tree) c1.getChildren()[0];

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
@@ -11,6 +11,7 @@
 package org.jcryptool.visual.jctca.tabs;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -36,10 +37,20 @@ public class CertificationTab {
     public CertificationTab(TabFolder parent, Composite exp, int style) {
         TabItem t = new TabItem(parent, SWT.NONE);
         t.setText(Messages.CertificationTab_tabitem_name);
-        Group generalGroup = new Group(parent, SWT.NONE);
+        
+        ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
+        scrolledComposite.setExpandHorizontal(true);
+        scrolledComposite.setExpandVertical(true);
+        scrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        scrolledComposite.setLayout(new GridLayout());
+        
+        Group generalGroup = new Group(scrolledComposite, SWT.NONE);
         generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
-        t.setControl(generalGroup);
+        t.setControl(scrolledComposite);
         new ShowReq(generalGroup, exp);
         generalGroup.setLayout(new GridLayout(1, false));
+        
+        scrolledComposite.setContent(generalGroup);
+        
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
@@ -39,8 +39,7 @@ public class CertificationTab {
         Group generalGroup = new Group(parent, SWT.NONE);
         generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
         t.setControl(generalGroup);
-        @SuppressWarnings("unused")
-        ShowReq sReq = new ShowReq(generalGroup, exp);
+        new ShowReq(generalGroup, exp);
         generalGroup.setLayout(new GridLayout(1, false));
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
@@ -11,6 +11,7 @@
 package org.jcryptool.visual.jctca.tabs;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -36,10 +37,21 @@ public class RegistrationTab {
     public RegistrationTab(TabFolder parent, Composite exp, int style) {
         TabItem t = new TabItem(parent, SWT.NONE);
         t.setText(Messages.RegistrationTab_tabitem_name);
-        Group generalGroup = new Group(parent, SWT.NONE);
-        generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
-        t.setControl(generalGroup);
+        
+        ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.V_SCROLL | SWT.H_SCROLL);
+        scrolledComposite.setExpandHorizontal(true);
+        scrolledComposite.setExpandVertical(true);
+        scrolledComposite.setLayout(new GridLayout());
+        scrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        
+        Group generalGroup = new Group(scrolledComposite, SWT.NONE);
+//        generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
+        generalGroup.setLayout(new GridLayout());
+        generalGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        t.setControl(scrolledComposite);
         new ShowCSR(generalGroup, exp);
-        generalGroup.setLayout(new GridLayout(1, false));
+        
+        scrolledComposite.setContent(generalGroup);
+        
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
@@ -39,8 +39,7 @@ public class RegistrationTab {
         Group generalGroup = new Group(parent, SWT.NONE);
         generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
         t.setControl(generalGroup);
-        @SuppressWarnings("unused")
-        ShowCSR sCSR = new ShowCSR(generalGroup, exp);
+        new ShowCSR(generalGroup, exp);
         generalGroup.setLayout(new GridLayout(1, false));
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
@@ -11,6 +11,7 @@
 package org.jcryptool.visual.jctca.tabs;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -36,10 +37,21 @@ public class SecondUserTab {
     public SecondUserTab(TabFolder parent, Composite exp, int style) {
         TabItem t = new TabItem(parent, SWT.NONE);
         t.setText(Messages.SecondUserTab_tabitem_name);
-        Group generalGroup = new Group(parent, SWT.NONE);
-        generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
-        t.setControl(generalGroup);
+        
+        ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
+        scrolledComposite.setExpandHorizontal(true);
+        scrolledComposite.setExpandVertical(true);
+        scrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        scrolledComposite.setLayout(new GridLayout());
+        
+        Group generalGroup = new Group(scrolledComposite, SWT.NONE);
+//        generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));#
+        generalGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        t.setControl(scrolledComposite);
         new ShowSigData(generalGroup, exp);
         generalGroup.setLayout(new GridLayout(1, false));
+        
+        scrolledComposite.setContent(generalGroup);
+        
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
@@ -39,8 +39,7 @@ public class SecondUserTab {
         Group generalGroup = new Group(parent, SWT.NONE);
         generalGroup.setLayoutData(new GridData(SWT.TOP, SWT.TOP, true, true, 1, 1));
         t.setControl(generalGroup);
-        @SuppressWarnings("unused")
-        ShowSigData sSig = new ShowSigData(generalGroup, exp);
+        new ShowSigData(generalGroup, exp);
         generalGroup.setLayout(new GridLayout(1, false));
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
@@ -41,7 +41,7 @@ public class UserTab {
         TabItem tab = new TabItem(parent, SWT.NONE);
         tab.setText(Messages.UserTab_tabitem_name);
         Group grp_userTab = new Group(parent, SWT.NONE);
-        grp_userTab.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, false, 1, 1));
+        grp_userTab.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
         tab.setControl(grp_userTab);
         this.grp_exp = exp;
 
@@ -55,36 +55,37 @@ public class UserTab {
 
         Composite right = new Composite(grp_userTab, SWT.NONE);
         right.setLayout(new GridLayout(1, true));
-        right.setLayoutData(new GridData(GridData.FILL_BOTH));
+        right.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
         SideBarListener list_side = new SideBarListener(grp_exp, right);
 
         Group g1 = new Group(left, SWT.NONE);
         g1.setText(Messages.UserTab_PKI_processes);
-        g1.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        g1.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         g1.setLayout(new GridLayout(1, true));
 
         Button btn_create_cert = new Button(g1, SWT.PUSH);
         btn_create_cert.setText(Messages.UserTab_btn_get_new_cert);
         btn_create_cert.setData(0); // set data for listener - see SideBarListener.java
         btn_create_cert.addSelectionListener(list_side);
-        btn_create_cert.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_create_cert.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 
         Button btn_show_cert = new Button(g1, SWT.PUSH);
         btn_show_cert.setText(Messages.UserTab_btn_manage_certs);
         btn_show_cert.setData(1);
         btn_show_cert.addSelectionListener(list_side);
-        btn_show_cert.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_show_cert.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
         Group g2 = new Group(left, SWT.None);
         g2.setText(Messages.UserTab_User_processes);
         g2.setLayout(new GridLayout(1, true));
-        g2.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        g2.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
         Button btn_sign_stuff = new Button(g2, SWT.PUSH);
         btn_sign_stuff.setText(Messages.UserTab_btn_sign_text_or_file);
         btn_sign_stuff.setData(2);
-        btn_sign_stuff.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        btn_sign_stuff.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         btn_sign_stuff.addSelectionListener(list_side);
+        
     }
 }

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
@@ -11,6 +11,7 @@
 package org.jcryptool.visual.jctca.tabs;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -40,9 +41,16 @@ public class UserTab {
         // define the layout for the whole TabItem
         TabItem tab = new TabItem(parent, SWT.NONE);
         tab.setText(Messages.UserTab_tabitem_name);
-        Group grp_userTab = new Group(parent, SWT.NONE);
+        
+        ScrolledComposite scrolledComposite = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
+        scrolledComposite.setExpandHorizontal(true);
+        scrolledComposite.setExpandVertical(true);
+        scrolledComposite.setLayout(new GridLayout());
+        tab.setControl(scrolledComposite);
+        
+        
+        Group grp_userTab = new Group(scrolledComposite, SWT.NONE);
         grp_userTab.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-        tab.setControl(grp_userTab);
         this.grp_exp = exp;
 
         // 2 columns (actions and the actionswindow)
@@ -51,7 +59,7 @@ public class UserTab {
         // Grid-Layout for all the buttons on the left side
         Composite left = new Composite(grp_userTab, SWT.NONE);
         left.setLayout(new GridLayout(1, true));
-        left.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false, 1, 1));
+        left.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
 
         Composite right = new Composite(grp_userTab, SWT.NONE);
         right.setLayout(new GridLayout(1, true));
@@ -68,7 +76,7 @@ public class UserTab {
         btn_create_cert.setText(Messages.UserTab_btn_get_new_cert);
         btn_create_cert.setData(0); // set data for listener - see SideBarListener.java
         btn_create_cert.addSelectionListener(list_side);
-        btn_create_cert.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+        btn_create_cert.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
         Button btn_show_cert = new Button(g1, SWT.PUSH);
         btn_show_cert.setText(Messages.UserTab_btn_manage_certs);
@@ -86,6 +94,9 @@ public class UserTab {
         btn_sign_stuff.setData(2);
         btn_sign_stuff.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         btn_sign_stuff.addSelectionListener(list_side);
+        
+        scrolledComposite.setContent(grp_userTab);
+        scrolledComposite.setMinSize(grp_userTab.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         
     }
 }


### PR DESCRIPTION
GUI improvements in the JCT Public-Key-Infrastructure Plugin.
 - Fixed the scrolledComposite, in which all content is shown. It now shows the scrollbars when needed.
 - The setFocus methods had until now no content. There, I've given the ScrolledComposite so you can scroll directly.
- some other GUI improvements:
The main view:
<img width="810" alt="certificationcheck_old" src="https://user-images.githubusercontent.com/20046726/34785636-0773754e-f632-11e7-8197-ecd733d7118a.PNG">
<img width="810" alt="certificationcheck_new" src="https://user-images.githubusercontent.com/20046726/34785658-12e222ea-f632-11e7-85e4-c1635de3a2c6.PNG">

The new csr tab:
<img width="810" alt="owncertificates_old" src="https://user-images.githubusercontent.com/20046726/34785723-4af024de-f632-11e7-88d0-33234d5a3cd7.PNG">
<img width="810" alt="owncertificates_new" src="https://user-images.githubusercontent.com/20046726/34785724-4bdd6b9a-f632-11e7-86ae-2857c4ae7563.PNG">

The behavior of the window, if you pull it smaller:
<img width="270" alt="compressed_old" src="https://user-images.githubusercontent.com/20046726/34785748-5b6989ea-f632-11e7-8273-a3495ead47bd.PNG">
The revised version displays scrollbars.
<img width="323" alt="compressed_new" src="https://user-images.githubusercontent.com/20046726/34785796-78107b4e-f632-11e7-923c-d1fc60ebf32b.PNG">



There is still a bug in the Certification Authority Tab that may cause the certificate not to be created. This error occurs if certificates with "JCT-PKI Root Certificates" in their name already exist in the keystore.

References #117 