### PR TITLE
ElGamal Key selection dialog changes

### DIFF
--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewKeypairPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewKeypairPage.java
@@ -64,7 +64,7 @@ public class NewKeypairPage extends WizardPage {
     private Combo gfield;
 
     /** field for entering the private b */
-    private Text bfield;
+    private Combo bfield;
 
     /** field for entering the public B */
     private Text btext;
@@ -244,8 +244,11 @@ public class NewKeypairPage extends WizardPage {
         
         new Label(composite, SWT.NONE).setText("b = "); //$NON-NLS-1$
         
-        bfield = new Text(composite, SWT.SINGLE | SWT.BORDER);
+        bfield = new Combo(composite, SWT.SINGLE | SWT.BORDER);
         bfield.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+        for (int i = 2; i < 100; i++) {
+			bfield.add(Integer.toString(i));
+		}
         bfield.addVerifyListener(VL);
         bfield.addModifyListener(listenerCalculateB);
         


### PR DESCRIPTION
I changed the field for b in the the key selection dialog in ElGamal. Previously you had to enter a value in a text field. Now the user can either type a value to the field or select one from a combo box.
<img width="495" alt="key_selection_old" src="https://user-images.githubusercontent.com/20046726/48950983-484f4c00-ef3d-11e8-8ee8-83c9e60c8256.PNG">
<img width="495" alt="key_selection_new" src="https://user-images.githubusercontent.com/20046726/48950985-49807900-ef3d-11e8-96a6-a9a4ff8f540f.PNG">
