### PR TITLE
Sudoku #3PR Various changes

### DIFF
--- a/org.jcryptool.games.sudoku/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.games.sudoku/OSGI-INF/l10n/bundle.properties
@@ -3,3 +3,4 @@ Bundle-Vendor = jcryptool.org, by Coen Ramaekers
 Bundle-Name = Sudoku Plug-in
 view.name = Sudoku-Solver
 Game.name = Sudoku-Solver
+restart.command.name = Reset

--- a/org.jcryptool.games.sudoku/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.games.sudoku/OSGI-INF/l10n/bundle_de.properties
@@ -3,3 +3,4 @@ Bundle-Vendor = jcryptool.org, von Coen Ramaekers
 Bundle-Name = Sudoku Plug-in
 view.name = Sudoku-Solver
 Game.name = Sudoku-Solver
+restart.command.name = Zurücksetzen

--- a/org.jcryptool.games.sudoku/plugin.xml
+++ b/org.jcryptool.games.sudoku/plugin.xml
@@ -32,5 +32,32 @@
             file="$nl$/contexts.xml">
       </contexts>
    </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.jcryptool.games.sudoku.handler.RestartHandler"
+            commandId="org.jcryptool.games.sudoku.restartCommand">
+      </handler>
+   </extension>
+   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            id="org.jcryptool.games.sudoku.restartCommand"
+            name="%restart.command.name">
+      </command>
+   </extension>
+   <extension
+         id="menu:org.jcryptool.games.sudoku.view"
+         point="org.eclipse.ui.menus">
+      <menuContribution
+             allPopups="false"
+             locationURI="toolbar:org.jcryptool.games.sudoku.views.SudokuView">
+         <command
+               commandId="org.jcryptool.games.sudoku.restartCommand"
+               icon="platform:/plugin/org.eclipse.ui/icons/full/etool16/new_wiz.png"
+               style="push">
+         </command>
+      </menuContribution>
+   </extension>
 
 </plugin>

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/Messages.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/Messages.java
@@ -20,6 +20,8 @@ public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.jcryptool.games.sudoku.messages"; //$NON-NLS-1$
 	public static String HexTabTitle;
 	public static String KillerTabTitle;
+	public static String NormalPuzzle_restartPuzzle;
+	public static String NormalPuzzle_restartPuzzleTooltip;
 	public static String NormalTabTitle;
 	public static String SudokuComposite_ActionsAreaTitle;
 	public static String SudokuComposite_AdditionButton;

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/SudokuPlugin.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/SudokuPlugin.java
@@ -67,4 +67,5 @@ public class SudokuPlugin extends AbstractUIPlugin {
 	public static ImageDescriptor getImageDescriptor(String path) {
 		return imageDescriptorFromPlugin(PLUGIN_ID, path);
 	}
+
 }

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/handler/RestartHandler.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/handler/RestartHandler.java
@@ -1,0 +1,32 @@
+package org.jcryptool.games.sudoku.handler;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.handlers.HandlerUtil;
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2017 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+* Public License v1.0 which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
+import org.jcryptool.games.sudoku.views.SudokuView;
+
+/**
+ * 
+ * @author Thorben Groos
+ *
+ */
+public class RestartHandler extends AbstractHandler {
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        if (HandlerUtil.getActivePart(event) instanceof SudokuView) {
+        	SudokuView view = ((SudokuView) HandlerUtil.getActivePart(event));
+                
+                view.reset();
+        }
+        return null;
+    }
+}

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/messages.properties
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/messages.properties
@@ -1,6 +1,8 @@
 SudokuComposite_MainGroup_Title=Sudoku
 HexTabTitle=Hexadecimal Sudoku
 KillerTabTitle=Killer Sudoku
+NormalPuzzle_restartPuzzle=Restart Puzzle
+NormalPuzzle_restartPuzzleTooltip=Resets the sudoku to its initial state.
 NormalTabTitle=Normal Sudoku
 
 SudokuComposite_Normal_Title=Normal Sudoku

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/messages_de.properties
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/messages_de.properties
@@ -1,4 +1,6 @@
 SudokuComposite_MainGroup_Title=Sudoku-L\u00F6ser
+NormalPuzzle_restartPuzzle=Neustart
+NormalPuzzle_restartPuzzleTooltip=Setzt das Sudoku auf den Anfangsstand zurück.
 NormalTabTitle=9*9-Sudoku
 KillerTabTitle=Killer-Sudoku
 HexTabTitle=16*16-Sudoku

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/HexPuzzle.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/HexPuzzle.java
@@ -131,12 +131,6 @@ public class HexPuzzle extends Composite {
 		createMain(this);
 		
 		showPossibleButton.setBackground(ColorService.GREEN);
-		
-//		for (int i = 0; i < 16; i++) {
-//			for (int j = 0; j < 16; j++) {
-//					givenHex[i][j] = 0;
-//			}
-//		}
 
 		refresh = new Runnable() {
 			@Override
@@ -549,7 +543,7 @@ public class HexPuzzle extends Composite {
 					for (int i = 0; i < 16; i++) {
 						for (int j = 0; j < 16; j++) {
 							boardHex[i][j] = originalSudoku[i][j];
-							boardTextHex[i][j].setText(Integer.toHexString(originalSudoku[i][j]).toUpperCase());
+							boardTextHex[i][j].setText(valToTextHex(originalSudoku[i][j]));
 						}
 					}
 				}
@@ -959,7 +953,8 @@ public class HexPuzzle extends Composite {
 					boardLabelsHex[i][j][k] = createLabelHex(labelCellHex[i][j], k);
 				}
 				if (boardHex[i][j] != -1)
-					boardTextHex[i][j].setText(Integer.toString(boardHex[i][j]));
+//					boardTextHex[i][j].setText(Integer.toString(boardHex[i][j]));
+					boardTextHex[i][j].setText(valToTextHex(boardHex[i][j]));
 				else {
 					if (possibleHex.get(i).get(j).size() < 9) {
 						for (int k = 0; k < possibleHex.get(i).get(j).size(); k++) {
@@ -983,26 +978,12 @@ public class HexPuzzle extends Composite {
 	}
 	
 	/**
-	 * Converts an int into a corresponding string value.
+	 * Converts an int into a corresponding string value.<br>
+	 * The method is only a <code>Integer.toHexString(val).toUpperCase();</code>
 	 * @param val The value that should be converted.
 	 * @return A string 'A', 'B', 'C', 'D', 'E' or 'F'.
 	 */
 	private String valToTextHex(int val) {
-//		switch (val) {
-//		case 10:
-//			return "A";
-//		case 11:
-//			return "B";
-//		case 12:
-//			return "C";
-//		case 13:
-//			return "D";
-//		case 14:
-//			return "E";
-//		case 15:
-//			return "F";
-//		}
-//		return Integer.toString(val);
 		return Integer.toHexString(val).toUpperCase();
 	}
 	
@@ -1211,7 +1192,9 @@ public class HexPuzzle extends Composite {
 			for (int j = 0; j < 16 & !changed; j++) {
 				if (possibleHex.get(i).get(j).size() == 1) {
 					boardHex[i][j] = possibleHex.get(i).get(j).get(0);
-					boardTextHex[i][j].setText(Integer.toString(boardHex[i][j]));
+//					boardTextHex[i][j].setText(Integer.toString(boardHex[i][j]));
+//					boardTextHex[i][j].setText(Integer.toHexString(boardHex[i][j]).toUpperCase());
+					boardTextHex[i][j].setText(valToTextHex(boardHex[i][j]));
 					labelCellHex[i][j].layout();
 					startBlinkingArea(i, j);
 					changed = true;
@@ -2673,6 +2656,14 @@ public class HexPuzzle extends Composite {
 		input.setBackground(ColorService.WHITE);
 		input.setTextLimit(1);
 		input.setFont(FontService.getSmallFont());
+//		input.addVerifyListener(new VerifyListener() {
+//			
+//			@Override
+//			public void verifyText(VerifyEvent e) {
+//				// TODO Auto-generated method stub
+//			}
+//		});
+
 		input.addListener(SWT.Verify, new Listener() {
 			@Override
 			public void handleEvent(Event e) {
@@ -2684,30 +2675,21 @@ public class HexPuzzle extends Composite {
 					updateBoardDataWithUserInputHex(textbox, input);
 				}
 				if (!solved && !loading && !solving) {
-					if (input.toUpperCase().equals("A") && possibleHex.get(point.x).get(point.y).indexOf(10) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(10));
+					input = input.toUpperCase();
+					if (input.equals("A") && possibleHex.get(point.x).get(point.y).indexOf(10) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "10");
-					} else if (input.toUpperCase().equals("B")
-							&& possibleHex.get(point.x).get(point.y).indexOf(11) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(11));
+					} else if (input.equals("B") && possibleHex.get(point.x).get(point.y).indexOf(11) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "11");
-					} else if (input.toUpperCase().equals("C")
-							&& possibleHex.get(point.x).get(point.y).indexOf(12) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(12));
+					} else if (input.equals("C") && possibleHex.get(point.x).get(point.y).indexOf(12) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "12");
-					} else if (input.toUpperCase().equals("D")
-							&& possibleHex.get(point.x).get(point.y).indexOf(13) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(13));
+					} else if (input.equals("D") && possibleHex.get(point.x).get(point.y).indexOf(13) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "13");
-					} else if (input.toUpperCase().equals("E")
-							&& possibleHex.get(point.x).get(point.y).indexOf(14) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(14));
+					} else if (input.equals("E") && possibleHex.get(point.x).get(point.y).indexOf(14) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "14");
-					} else if (input.toUpperCase().equals("F")
-							&& possibleHex.get(point.x).get(point.y).indexOf(15) != -1) {
-//						updateBoardDataWithUserInputHex(textbox, Integer.toString(15));
+					} else if (input.equals("F") && possibleHex.get(point.x).get(point.y).indexOf(15) != -1) {
 						updateBoardDataWithUserInputHex(textbox, "15");
 					} else {
+						//Der check auf Längen > 1 ist sinnlos, da das text Limit von Text input 1 ist.
 						char[] chars = new char[input.length()];
 						input.getChars(0, chars.length, chars, 0);
 						for (int i = 0; i < chars.length; i++) {
@@ -2718,12 +2700,14 @@ public class HexPuzzle extends Composite {
 								return;
 							}
 						}
-						input = input.toUpperCase();
 						updateBoardDataWithUserInputHex(textbox, input);
 					}
+					e.text = input;
 				}
 			}
 		});
+
+		//Return the textfield
 		return input;
 	}
 	

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/KillerPuzzle.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/KillerPuzzle.java
@@ -1252,6 +1252,7 @@ public class KillerPuzzle extends Composite {
 		possibleKiller = new ArrayList<List<List<Integer>>>();
 		selected = new ArrayList<Point>();
 		areas = new ArrayList<Area>();
+		
 		for (int i = 0; i < 9; i++) {
 			possibleKiller.add(new ArrayList<List<Integer>>());
 			for (int j = 0; j < 9; j++) {
@@ -1294,7 +1295,6 @@ public class KillerPuzzle extends Composite {
 									composite.setBackground(ColorService.WHITE);
 									boardTextKiller[point.x][point.y].setBackground(ColorService.WHITE);
 									selected.remove(point);
-
 								} else {
 									if (adjacent(point)) {
 										composite.setBackground(ColorService.RED);
@@ -1371,9 +1371,9 @@ public class KillerPuzzle extends Composite {
 				for (int k = 4; k < 8; k++) {
 					boardLabelsKiller[i][j][k] = createLabelKiller(labelCellKiller[i][j]);
 				}
-				if (boardKiller[i][j] != 0)
+				if (boardKiller[i][j] != 0) {
 					boardTextKiller[i][j].setText(Integer.toString(boardKiller[i][j]));
-				else {
+				} else {
 					if (possibleKiller.get(i).get(j).size() < 8) {
 						for (int k = 0; k < possibleKiller.get(i).get(j).size(); k++) {
 							boardLabelsKiller[i][j][k + 1]
@@ -1853,6 +1853,12 @@ public class KillerPuzzle extends Composite {
 				}
 				
 				refresh();
+				
+				for (int i = 0; i < 9; i++) {
+					for (int j = 0; j < 9; j++) {
+						labelCellKiller[i][j].redraw();
+					}
+				}
 
 				enterModeButton.setSelection(false);
 				solveModeButton.setSelection(true);
@@ -1876,6 +1882,7 @@ public class KillerPuzzle extends Composite {
 			public void widgetSelected(SelectionEvent e) {
 				loadPuzzleKiller();
 				refresh();
+				
 			}
 			
 			@Override

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuComposite.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuComposite.java
@@ -513,7 +513,7 @@ public class SudokuComposite extends Composite {
 		getDisplay().asyncExec(refresh);
 	}
 
-	public void createButtonArea(final Composite parent) {
+	private void createButtonArea(final Composite parent) {
 		final Composite mainComposite = new Composite(parent, SWT.SHADOW_NONE);
 		mainComposite.setLayout(new GridLayout());
 		mainComposite.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false));

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuView.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuView.java
@@ -12,6 +12,7 @@ package org.jcryptool.games.sudoku.views;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.ui.PlatformUI;
@@ -20,15 +21,19 @@ import org.jcryptool.games.sudoku.Messages;
 import org.jcryptool.games.sudoku.SudokuPlugin;
 
 public class SudokuView extends ViewPart {
+	
+	private TabFolder tf;
+	private NormalPuzzle normalSudoku;
+	private KillerPuzzle killerSudoku;
+	private HexPuzzle hexadecimalSudoku;
+	
 
     public SudokuView() { }
 
-//    public final int NORMAL = 1, KILLER = 2, HEX = 3;
-    public final int KILLER = 2, HEX = 3;
-
 	@Override
 	public void createPartControl(final Composite parent) {
-		final TabFolder tf = new TabFolder(parent, SWT.TOP);
+		
+		tf = new TabFolder(parent, SWT.TOP);
 
 		//Normal 9*9 Sudoku Tab
         TabItem ti = new TabItem(tf, SWT.NONE);
@@ -36,10 +41,9 @@ public class SudokuView extends ViewPart {
         ScrolledComposite sc = new ScrolledComposite(tf, SWT.H_SCROLL | SWT.V_SCROLL);
         sc.setExpandHorizontal(true);
         sc.setExpandVertical(true);
-//        SudokuComposite c = new SudokuComposite(sc, NORMAL, SWT.NONE);
-        NormalPuzzle c = new NormalPuzzle(sc, SWT.NONE);
-        sc.setContent(c);
-        sc.setMinSize(c.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+        normalSudoku = new NormalPuzzle(sc, SWT.NONE);
+        sc.setContent(normalSudoku);
+        sc.setMinSize(normalSudoku.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         ti.setControl(sc);
 
         //Killer Sudoku Tab
@@ -48,10 +52,9 @@ public class SudokuView extends ViewPart {
         ScrolledComposite sc2 = new ScrolledComposite(tf, SWT.H_SCROLL | SWT.V_SCROLL);
         sc2.setExpandHorizontal(true);
         sc2.setExpandVertical(true);
-//        SudokuComposite c2 = new SudokuComposite(sc2, KILLER, SWT.NONE);
-        KillerPuzzle c2 = new KillerPuzzle(sc2, SWT.NONE);
-        sc2.setContent(c2);
-        sc2.setMinSize(c2.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+        killerSudoku = new KillerPuzzle(sc2, SWT.NONE);
+        sc2.setContent(killerSudoku);
+        sc2.setMinSize(killerSudoku.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         ti2.setControl(sc2);
 
         //Hex Sudoku Tab (16*16)
@@ -60,10 +63,9 @@ public class SudokuView extends ViewPart {
         ScrolledComposite sc3 = new ScrolledComposite(tf, SWT.H_SCROLL | SWT.V_SCROLL);
         sc3.setExpandHorizontal(true);
         sc3.setExpandVertical(true);
-//        SudokuComposite c3 = new SudokuComposite(sc3, HEX, SWT.NONE);
-        HexPuzzle c3 = new HexPuzzle(sc3, SWT.NONE);
-        sc3.setContent(c3);
-        sc3.setMinSize(c3.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+        hexadecimalSudoku = new HexPuzzle(sc3, SWT.NONE);
+        sc3.setContent(hexadecimalSudoku);
+        sc3.setMinSize(hexadecimalSudoku.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         ti3.setControl(sc3);
 
         PlatformUI.getWorkbench().getHelpSystem().setHelp(parent.getShell(), SudokuPlugin.PLUGIN_ID + ".sudokuview");
@@ -71,6 +73,33 @@ public class SudokuView extends ViewPart {
 
 	@Override
 	public void setFocus() {
+		
+	}
+	
+	/**
+	 * Resets the current Tabitem.</br>
+	 * Very ugly. Strong link between GUI and logic.</br>
+	 * Checks if the current tab item has a child which is an 
+	 * instance of NormalPuzzle, HexPuzzle or KillerPuzzle. If so
+	 * it calls the reset method of this class. 
+	 */
+	public void reset() {
+
+		//Get the current tab item 
+		TabItem tit = tf.getItem(tf.getSelectionIndex());
+		Control ctr = tit.getControl();
+		// ctr has only one child. NormalPuzzle or KillerPuzzle or HexPuzzle.
+		Control [] childs = ((Composite) ctr).getChildren();
+		if (childs[0] instanceof NormalPuzzle) {
+			NormalPuzzle np = (NormalPuzzle) childs[0];
+			np.reset();
+		} else if (childs[0] instanceof KillerPuzzle) {
+			KillerPuzzle kp = (KillerPuzzle) childs[0];
+			kp.reset();
+		} else if (childs[0] instanceof HexPuzzle) {
+			HexPuzzle hp = (HexPuzzle) childs[0];
+			hp.reset();
+		}	
 	}
 
 


### PR DESCRIPTION
I removed the reset button from the left column with the buttons. He is now in the top right corner of the plugin, where he is in most other plugins too.
<img width="618" alt="reset button top right" src="https://user-images.githubusercontent.com/20046726/50740699-9325da00-11f2-11e9-8305-f53646efa251.PNG">

It is now possible to restart sudoku. For this I added a button "Restart" to the buttons on the left side. The sudoku is saved as soon as the user switches from enter mode to solve mode or when he loads a sudoku.
<img width="618" alt="restart button" src="https://user-images.githubusercontent.com/20046726/50740743-51e1fa00-11f3-11e9-84b5-6ca5b4619b63.PNG">

Values that are fixed are printed bold and unchangeable.
<img width="618" alt="restart button" src="https://user-images.githubusercontent.com/20046726/50740782-e3ea0280-11f3-11e9-96b6-42a6ff41f9bc.PNG">

In Hex Sudokus, all letters are now capitalized. For example, if you enter a lowercase letter b, a capital B will be displayed.

Some bug fixes


Refers to #47 

