### PR TITLE
Fix for wrong values in ECC visualization

### DIFF
--- a/org.jcryptool.visual.ecc/META-INF/MANIFEST.MF
+++ b/org.jcryptool.visual.ecc/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Bundle-Activator: org.jcryptool.visual.ecc.ECCPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Import-Package: org.jcryptool.core.logging.utils,
+ org.jcryptool.core.util.colors,
  org.jcryptool.core.util.constants,
  org.jcryptool.core.util.directories,
  org.jcryptool.core.util.fonts

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
@@ -93,7 +93,7 @@ public class EC {
 		ArrayList<Double> listX = new ArrayList<Double>();
 		ArrayList<Double> listY = new ArrayList<Double>();
 		numPoints = 1;
-		double xStep = Math.pow((double)gridSize, -1);
+		double xStep = Math.pow(gridSize, -1);
 		double xVal;
 		double yVal;
 		boolean lastPoint = false;
@@ -249,6 +249,7 @@ public class EC {
 		return r;
 	}
 
+	@Override
 	public String toString() {
 		String s = "y\u00b2 = x\u00b3"; //$NON-NLS-1$
 		if(A == 1)

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
@@ -127,7 +127,7 @@ public class EC {
 					//Es wird ein yVal gesucht, welcher näher an 0 liegt 
 					//als der yVal der sich bei einsetzen von xVal ergibt.
 					do {
-						sXVNZ = sXVNZ - xStep *  0.01;
+						sXVNZ = sXVNZ - xStep *  0.001;
 					} while ((Math.pow(sXVNZ, 3) + A * sXVNZ + B) >= 0);
 					
 					//Werte auf zwei Nachkommastellen runden
@@ -179,29 +179,9 @@ public class EC {
 				pointsY[i] = listY.get(i);
 
 				points[i] = new FpPoint((int)(listX.get(i) * 100), (int)(listY.get(i) * 100));
-				
-                // ---- Mein Scheiss zum debuggen
-//                if (pointsX[i] < 2) {
-//                	System.out.print("i:" + i + "\tpointsX:" + listX.get(i));
-//                	System.out.print("\tpointsY:" + listY.get(i));
-//                	System.out.println("\tpoints" + points[i].toString());
-//                }
 			}
 		}
 	}
-	
-	/**
-	 * Approximates the value to an accuracy of 0.01
-	 * @param xValue
-	 * @param xStep
-	 * @return
-	 */
-//	private double approximateNearestXValue(double xValue, double xStep) {
-//		do {
-//			xValue = xValue - xStep *  0.01;
-//		} while ((Math.pow(xValue, 3) + A * xValue + B) >= 0);
-//		return xValue;
-//	}
 
 	public FpPoint[] getPoints() {
 		return points;

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFm.java
@@ -38,6 +38,7 @@ public class ECFm extends EC{
 		setM(m);
 	}
 
+	@Override
 	public FpPoint addPoints(FpPoint p, FpPoint q) {
 		if(p == null || q == null)
 			return null;
@@ -100,6 +101,7 @@ public class ECFm extends EC{
 		return M;
 	}
 
+	@Override
 	public int getType() {
 		return ECFm;
 	}
@@ -302,6 +304,7 @@ public class ECFm extends EC{
 			return b[1];
 	}
 
+	@Override
 	public String toString() {
 		String s = "y\u00b2 + xy = x\u00b3 + "; //$NON-NLS-1$
 		if(indexA == 0)

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFp.java
@@ -26,6 +26,7 @@ public class ECFp extends EC{
 		return P;
 	}
 
+	@Override
 	public int getType() {
 		return ECFp;
 	}
@@ -78,6 +79,7 @@ public class ECFp extends EC{
 			points[i] = list.get(i);
 	}
 
+	@Override
 	public FpPoint addPoints(FpPoint p, FpPoint q) {
 		if(p == null || q == null)
 			return null;
@@ -142,6 +144,7 @@ public class ECFp extends EC{
 			return b[1];
 	}
 
+	@Override
 	public String toString() {
 		String s = "y\u00b2 mod " + P + " = (x\u00b3"; //$NON-NLS-1$ //$NON-NLS-2$
 		if(A == 1)

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/handlers/RestartHandler.java
@@ -22,7 +22,8 @@ import org.jcryptool.visual.ecc.ui.ECView;
  * @version 0.9.5
  */
 public class RestartHandler extends AbstractHandler {
-    public Object execute(ExecutionEvent event) throws ExecutionException {
+    @Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
         if (HandlerUtil.getActivePart(event) instanceof ECView) {
         	ECView view = ((ECView) HandlerUtil.getActivePart(event));
                 

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
@@ -163,7 +163,9 @@ public class ECContentFm extends Composite{
 		btnDeletePoints.setLayoutData(new GridData(SWT.RIGHT, SWT.FILL, false, false));
 		btnDeletePoints.setEnabled(false);
 		btnDeletePoints.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				btnPQ.setSelection(true);
 				btnPQ.setEnabled(false);
@@ -186,7 +188,9 @@ public class ECContentFm extends Composite{
 		sliderZoom.setMinimum(0);
 		sliderZoom.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
 		sliderZoom.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				points = null;
 				fillTablePoints();
@@ -218,7 +222,9 @@ public class ECContentFm extends Composite{
 		rbtnLarge.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnLarge.setText(Messages.getString("ECView.Large")); //$NON-NLS-1$
 		rbtnLarge.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showLarge();
 			}
@@ -253,6 +259,7 @@ public class ECContentFm extends Composite{
 		groupPoints.setLayout(new GridLayout(1, false));
 		groupPoints.setText(Messages.getString("ECView.Points")); //$NON-NLS-1$
 		groupPoints.addListener(SWT.Resize, new Listener(){
+			@Override
 			public void handleEvent(Event event) {
 				fillTablePoints();
 			}
@@ -265,7 +272,9 @@ public class ECContentFm extends Composite{
 		tcPoints = new TableCursor(tablePoints, SWT.NONE);
 		tcPoints.setForeground(red);
 		tcPoints.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				int index = -1;
 				for(int i = 0; i < tiPoints.length; i++) {
@@ -301,15 +310,17 @@ public class ECContentFm extends Composite{
 		canvasCurve.setLayoutData(gridData);
 		canvasCurve.setSize(500,500);
 		canvasCurve.addPaintListener(new PaintListener(){
+			@Override
 			public void paintControl(PaintEvent e) {
 				drawDiscrete(e);
 			}
 		});
 		canvasCurve.addMouseMoveListener(new MouseMoveListener(){
+			@Override
 			public void mouseMove(MouseEvent e) {
 				Point size = canvasCurve.getSize();
 				if (points != null){
-					double grid = (double)(size.x - 30) / (Math.pow(2, spnrM.getSelection()) - 1);
+					double grid = (size.x - 30) / (Math.pow(2, spnrM.getSelection()) - 1);
 					double x = (e.x - 25) / grid;
 					double y = (size.y - e.y - 25) / grid;
 
@@ -321,6 +332,7 @@ public class ECContentFm extends Composite{
 			}
 		});
 		canvasCurve.addListener(SWT.MouseDown, new Listener(){
+			@Override
 			public void handleEvent(Event event) {
 				if(pointSelect != null) {
 					if(pointP == null) {
@@ -332,7 +344,9 @@ public class ECContentFm extends Composite{
 			}
 		});
 		canvasCurve.addMouseTrackListener(new MouseTrackListener(){
+			@Override
 			public void mouseEnter(MouseEvent e) {}
+			@Override
 			public void mouseExit(MouseEvent e) {
 				pointSelect = null;
 				updateCurve(false);
@@ -342,6 +356,7 @@ public class ECContentFm extends Composite{
 				if(pointQ == null)
 					lblQ.setText(""); //$NON-NLS-1$
 			}
+			@Override
 			public void mouseHover(MouseEvent e) {}
 		});
 	}
@@ -363,11 +378,13 @@ public class ECContentFm extends Composite{
         cSaveResults.select(view.saveTo);
         cSaveResults.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cSaveResults.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveTo = cSaveResults.getSelectionIndex();
                 btnBrowse.setEnabled(view.saveTo == 2);
                 btnSave.setEnabled(view.saveTo != 0);
@@ -382,11 +399,13 @@ public class ECContentFm extends Composite{
         btnBrowse.setText(Messages.getString("ECView.Browse")); //$NON-NLS-1$
         btnBrowse.setEnabled(view.saveTo == 2);
         btnBrowse.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.selectFileLocation();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -395,11 +414,13 @@ public class ECContentFm extends Composite{
         btnSave.setText(Messages.getString("ECView.SaveNow")); //$NON-NLS-1$
         btnSave.setEnabled(view.saveTo != 0);
         btnSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveLog();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -409,11 +430,13 @@ public class ECContentFm extends Composite{
         cbAutoSave.setEnabled(view.autoSave);
         cbAutoSave.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cbAutoSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.autoSave = cbAutoSave.getSelection();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -437,7 +460,9 @@ public class ECContentFm extends Composite{
 		rbtnReal.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnReal.setSelection(false);
 		rbtnReal.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showReal();
 			}
@@ -448,7 +473,9 @@ public class ECContentFm extends Composite{
 		rbtnFP.setSelection(false);
 		rbtnFP.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFP.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showFp();
 			}
@@ -458,7 +485,9 @@ public class ECContentFm extends Composite{
 		rbtnFM.setSelection(true);
 		rbtnFM.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFM.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showFm();
 			}
@@ -496,7 +525,9 @@ public class ECContentFm extends Composite{
 		spnrM.setSelection(4);
 		spnrM.setMinimum(3);
 		spnrM.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				((ECFm)curve).setM(spnrM.getSelection());
 				setComboF(((ECFm)curve).getIrreduciblePolinomials());
@@ -527,7 +558,9 @@ public class ECContentFm extends Composite{
 		cF.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		cF.select(0);
 		cF.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				((ECFm)curve).setF(cF.getSelectionIndex(), true);
 				elements =((ECFm)curve).getElements();
@@ -550,7 +583,9 @@ public class ECContentFm extends Composite{
 		gd_cA.widthHint = 100;
 		cA.setLayoutData(gd_cA);
 		cA.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				((ECFm)curve).setA(cA.getSelectionIndex(), true);
 				((ECFm)curve).setB(cB.getSelectionIndex(), true);
@@ -562,7 +597,9 @@ public class ECContentFm extends Composite{
 		label1.setText("b ="); //$NON-NLS-1$
 		cB = new Combo(groupCurveAttributes, SWT.READ_ONLY);
 		cB.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				((ECFm)curve).setA(cA.getSelectionIndex(), true);
 				((ECFm)curve).setB(cB.getSelectionIndex(), true);
@@ -580,7 +617,9 @@ public class ECContentFm extends Composite{
 		cbShowBinary.setText(Messages.getString("ECContentFm.40")); //$NON-NLS-1$
 		cbShowBinary.setLayoutData(gridData);
 		cbShowBinary.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				setPointP(pointP);
 				setPointQ(pointQ);
@@ -664,7 +703,9 @@ public class ECContentFm extends Composite{
 		btnPQ.setSelection(true);
 		btnPQ.setEnabled(false);
 		btnPQ.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				setPointQ(null);
 			}
@@ -676,7 +717,9 @@ public class ECContentFm extends Composite{
 		btnKP.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
 		btnKP.setEnabled(false);
 		btnKP.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				spnrK.setEnabled(btnKP.getSelection());
 				FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
@@ -693,7 +736,9 @@ public class ECContentFm extends Composite{
 		spnrK.setMaximum(1000);
 		spnrK.setEnabled(false);
 		spnrK.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
 				setPointQ(q);
@@ -855,6 +900,7 @@ public class ECContentFm extends Composite{
 		for(int i = 0; i < tiPoints.length; i++) {
 			tiPoints[i] = new TableItem(tablePoints, SWT.NONE);
 			tiPoints[i].addListener(SWT.Settings, new Listener(){
+				@Override
 				public void handleEvent(Event event) {
 					if((event.detail & SWT.SELECTED) != 0 ){
 						tablePoints.deselectAll();
@@ -969,10 +1015,10 @@ public class ECContentFm extends Composite{
 
 		TableItem[] tiElements = new TableItem[elements.length + 1];
 		tiElements[0] = new TableItem(tableElements, SWT.NONE);
-		tiElements[0].setText(new String[]{"1", "=", (cbShowBinary.getSelection() ? intToBitString(1, spnrM.getSelection()) : bits2Function(intToBitString(1, spnrM.getSelection()))+"                                     ")}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		tiElements[0].setText(new String[]{"1", "=", (cbShowBinary.getSelection() ? intToBitString(1, spnrM.getSelection()) : bits2Function(intToBitString(1, spnrM.getSelection()))+"                                     ")}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ 
 		for(int i = 1; i < elements.length; i++) {
 			tiElements[i] = new TableItem(tableElements, SWT.NONE);
-			tiElements[i].setText(new String[]{"g" + (i > 1 ? i : ""), "=", (cbShowBinary.getSelection() ? intToBitString(elements[i], spnrM.getSelection()) : bits2Function(intToBitString(elements[i], spnrM.getSelection())))}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			tiElements[i].setText(new String[]{"g" + (i > 1 ? i : ""), "=", (cbShowBinary.getSelection() ? intToBitString(elements[i], spnrM.getSelection()) : bits2Function(intToBitString(elements[i], spnrM.getSelection())))}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ 
 		}
 		tiElements[tiElements.length-1] = new TableItem(tableElements, SWT.NONE);
 		tiElements[tiElements.length-1].setText(new String[]{"0", "=", (cbShowBinary.getSelection() ? intToBitString(0, spnrM.getSelection()) : ""+0)}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
@@ -158,7 +158,9 @@ public class ECContentFp extends Composite{
 		btnDeletePoints.setLayoutData(new GridData(SWT.RIGHT, SWT.FILL, false, false));
 		btnDeletePoints.setEnabled(false);
 		btnDeletePoints.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				btnPQ.setSelection(true);
 				btnPQ.setEnabled(false);
@@ -181,7 +183,9 @@ public class ECContentFp extends Composite{
 		sliderZoom.setMinimum(0);
 		sliderZoom.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
 		sliderZoom.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				curve.updateCurve(spnrA.getSelection(), spnrB.getSelection(), 50 - sliderZoom.getSelection(), canvasCurve.getSize());
 				points = curve.getPoints();
@@ -217,6 +221,7 @@ public class ECContentFp extends Composite{
 		groupPoints.setLayout(new GridLayout(1, false));
 		groupPoints.setText(Messages.getString("ECView.Points")); //$NON-NLS-1$
 		groupPoints.addListener(SWT.Resize, new Listener(){
+			@Override
 			public void handleEvent(Event event) {
 				fillTablePoints();
 			}
@@ -228,7 +233,9 @@ public class ECContentFp extends Composite{
 		tcPoints = new TableCursor(tablePoints, SWT.NONE);
 		tcPoints.setForeground(red);
 		tcPoints.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				int index = -1;
 				for(int i = 0; i < tiPoints.length; i++) {
@@ -268,7 +275,9 @@ public class ECContentFp extends Composite{
 		rbtnLarge.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnLarge.setText(Messages.getString("ECView.Large")); //$NON-NLS-1$
 		rbtnLarge.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showLarge();
 			}
@@ -288,9 +297,11 @@ public class ECContentFp extends Composite{
 		canvasCurve.setLayoutData(gridData);
 		canvasCurve.setSize(500,500);
 		canvasCurve.addPaintListener(new PaintListener(){
+			@Override
 			public void paintControl(PaintEvent e) {drawDiscrete(e);}
 		});
 		canvasCurve.addMouseMoveListener(new MouseMoveListener(){
+			@Override
 			public void mouseMove(MouseEvent e) {
 				Point size = canvasCurve.getSize();
 				if (points != null){
@@ -306,6 +317,7 @@ public class ECContentFp extends Composite{
 			}
 		});
 		canvasCurve.addListener(SWT.MouseDown, new Listener(){
+			@Override
 			public void handleEvent(Event event) {
 				if(pointSelect != null) {
 					if(pointP == null) {
@@ -317,7 +329,9 @@ public class ECContentFp extends Composite{
 			}
 		});
 		canvasCurve.addMouseTrackListener(new MouseTrackListener(){
+			@Override
 			public void mouseEnter(MouseEvent e) {}
+			@Override
 			public void mouseExit(MouseEvent e) {
 				pointSelect = null;
 				updateCurve(false);
@@ -327,6 +341,7 @@ public class ECContentFp extends Composite{
 				if(pointQ == null)
 					lblQ.setText(""); //$NON-NLS-1$
 			}
+			@Override
 			public void mouseHover(MouseEvent e) {}
 		});
 	}
@@ -348,11 +363,13 @@ public class ECContentFp extends Composite{
         cSaveResults.select(view.saveTo);
         cSaveResults.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cSaveResults.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveTo = cSaveResults.getSelectionIndex();
                 btnBrowse.setEnabled(view.saveTo == 2);
                 btnSave.setEnabled(view.saveTo != 0);
@@ -367,11 +384,13 @@ public class ECContentFp extends Composite{
         btnBrowse.setText(Messages.getString("ECView.Browse")); //$NON-NLS-1$
         btnBrowse.setEnabled(view.saveTo == 2);
         btnBrowse.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.selectFileLocation();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -380,11 +399,13 @@ public class ECContentFp extends Composite{
         btnSave.setText(Messages.getString("ECView.SaveNow")); //$NON-NLS-1$
         btnSave.setEnabled(view.saveTo != 0);
         btnSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveLog();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -394,11 +415,13 @@ public class ECContentFp extends Composite{
         cbAutoSave.setEnabled(view.autoSave);
         cbAutoSave.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cbAutoSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.autoSave = cbAutoSave.getSelection();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -422,7 +445,9 @@ public class ECContentFp extends Composite{
 		rbtnReal.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnReal.setSelection(false);
 		rbtnReal.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showReal();
 			}
@@ -433,7 +458,9 @@ public class ECContentFp extends Composite{
 		rbtnFP.setSelection(true);
 		rbtnFP.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFP.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showFp();
 			}
@@ -443,7 +470,9 @@ public class ECContentFp extends Composite{
 		rbtnFM.setSelection(false);
 		rbtnFM.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFM.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				view.showFm();
 			}
@@ -474,7 +503,9 @@ public class ECContentFp extends Composite{
 		spnrA.setSelection(10);
 		spnrA.setMinimum(0);
 		spnrA.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				btnPQ.setSelection(true);
 				btnKP.setSelection(false);
@@ -496,7 +527,9 @@ public class ECContentFp extends Composite{
 		spnrB.setSelection(15);
 		spnrB.setMinimum(0);
 		spnrB.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				btnPQ.setSelection(true);
 				btnKP.setSelection(false);
@@ -518,7 +551,9 @@ public class ECContentFp extends Composite{
 		spnrP.setMinimum(3);
 		spnrP.setMaximum(1000);
 		spnrP.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				btnPQ.setSelection(true);
 				btnKP.setSelection(false);
@@ -598,7 +633,9 @@ public class ECContentFp extends Composite{
 		btnPQ.setSelection(true);
 		btnPQ.setEnabled(false);
 		btnPQ.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				setPointQ(null);
 			}
@@ -610,7 +647,9 @@ public class ECContentFp extends Composite{
 		btnKP.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
 		btnKP.setEnabled(false);
 		btnKP.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				spnrK.setEnabled(btnKP.getSelection());
 				FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
@@ -627,7 +666,9 @@ public class ECContentFp extends Composite{
 		spnrK.setMaximum(1000);
 		spnrK.setEnabled(false);
 		spnrK.addSelectionListener(new SelectionListener(){
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {widgetSelected(e);}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
 				setPointQ(q);
@@ -773,6 +814,7 @@ public class ECContentFp extends Composite{
 		for(int i = 0; i < tiPoints.length; i++) {
 			tiPoints[i] = new TableItem(tablePoints, SWT.NONE);
 			tiPoints[i].addListener(SWT.Settings, new Listener(){
+				@Override
 				public void handleEvent(Event event) {
 					if((event.detail & SWT.SELECTED) != 0 ){
 						tablePoints.deselectAll();

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
@@ -152,7 +152,9 @@ public class ECContentLarge extends Composite {
 		rbtnSmall.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnSmall.setText(Messages.getString("ECView.Small")); //$NON-NLS-1$
 		rbtnSmall.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnSmall.getSelection()) {
 					if(rbtnFP.getSelection())
@@ -233,7 +235,9 @@ public class ECContentLarge extends Composite {
 		rbtnFP.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFP.setSelection(true);
 		rbtnFP.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnFP.getSelection())
 					fillCSelection();
@@ -243,7 +247,9 @@ public class ECContentLarge extends Composite {
 		rbtnFM.setText("F(2^m)"); //$NON-NLS-1$
 		rbtnFM.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
 		rbtnFM.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnFM.getSelection())
 					fillCSelection();
@@ -284,7 +290,9 @@ public class ECContentLarge extends Composite {
 		cStandard = new Combo(groupSelectAttributes, SWT.NONE);
 		cStandard.setLayoutData(gridData9);
 		cStandard.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				fillCCurve();
 			}
@@ -303,7 +311,9 @@ public class ECContentLarge extends Composite {
 		cCurve = new Combo(groupSelectAttributes, SWT.NONE);
 		cCurve.setLayoutData(gridData10);
 		cCurve.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				setCurve();
 			}
@@ -341,7 +351,9 @@ public class ECContentLarge extends Composite {
 		btnClearPoints.setText(Messages.getString("ECView.ClearPoints")); //$NON-NLS-1$
 		btnClearPoints.setLayoutData(gridData45);
 		btnClearPoints.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				pointP = null;
 				pointQ = null;
@@ -354,7 +366,9 @@ public class ECContentLarge extends Composite {
 		rbtnPQ.setLayoutData(gridData6);
 		rbtnPQ.setSelection(true);
 		rbtnPQ.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				pointR = null;
 				updateScreen();
@@ -364,7 +378,9 @@ public class ECContentLarge extends Composite {
 		rbtnKP.setText(Messages.getString("ECContentLarge.18")); //$NON-NLS-1$
 		rbtnKP.setLayoutData(gridData5);
 		rbtnKP.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnKP.getSelection()) {
 					pointQ = null;
@@ -391,7 +407,9 @@ public class ECContentLarge extends Composite {
 		spnrK.setLayoutData(gridData29);
 		spnrK.setMaximum(Integer.MAX_VALUE);
 		spnrK.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				int i = spnrK.getSelection();
 				String s = "R = P + " + (i > 2 ? i - 1 : "") + "P"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -650,7 +668,9 @@ public class ECContentLarge extends Composite {
 		rbtnRadix2 = new Button(groupRadix, SWT.RADIO);
 		rbtnRadix2.setText(Messages.getString("ECView.Binary")); //$NON-NLS-1$
 		rbtnRadix2.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnRadix2.getSelection()) {
 					radix = 2;
@@ -661,7 +681,9 @@ public class ECContentLarge extends Composite {
 		rbtnRadix8 = new Button(groupRadix, SWT.RADIO);
 		rbtnRadix8.setText(Messages.getString("ECView.Octal")); //$NON-NLS-1$
 		rbtnRadix8.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnRadix8.getSelection()) {
 					radix = 8;
@@ -673,7 +695,9 @@ public class ECContentLarge extends Composite {
 		rbtnRadix10.setText(Messages.getString("ECView.Decimal")); //$NON-NLS-1$
 		rbtnRadix10.setSelection(true);
 		rbtnRadix10.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnRadix10.getSelection()) {
 					radix = 10;
@@ -684,7 +708,9 @@ public class ECContentLarge extends Composite {
 		rbtnRadix16 = new Button(groupRadix, SWT.RADIO);
 		rbtnRadix16.setText(Messages.getString("ECView.Hexadecimal")); //$NON-NLS-1$
 		rbtnRadix16.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(rbtnRadix16.getSelection()) {
 					radix = 16;
@@ -708,7 +734,9 @@ public class ECContentLarge extends Composite {
 		btnPGenerate.setText(Messages.getString("ECView.GenerateRandomPoint")); //$NON-NLS-1$
 		btnPGenerate.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		btnPGenerate.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(curve != null) {
 					if(pointP == null)
@@ -748,7 +776,9 @@ public class ECContentLarge extends Composite {
 		btnPGenerator.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		btnPGenerator.setText(Messages.getString("ECView.UseGeneratorG")); //$NON-NLS-1$
 		btnPGenerator.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(curve != null) {
 					if(pointP == null)
@@ -804,7 +834,9 @@ public class ECContentLarge extends Composite {
 		btnQGenerate.setText(Messages.getString("ECView.GenerateRandomPoint")); //$NON-NLS-1$
 		btnQGenerate.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 2, 1));
 		btnQGenerate.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) { }
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				if(curve != null) {
 					if(rbtnFP.getSelection())
@@ -827,7 +859,9 @@ public class ECContentLarge extends Composite {
 		btnQGenerator.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
 		btnQGenerator.setText(Messages.getString("ECView.UseGeneratorG")); //$NON-NLS-1$
 		btnQGenerator.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {}
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				pointQ = pointG;
 				view.log("\n" + Messages.getString("ECView.Point") + " Q = " + pointQ.toString() + "\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -891,11 +925,13 @@ public class ECContentLarge extends Composite {
         cSaveResults.select(view.saveTo);
         cSaveResults.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cSaveResults.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveTo = cSaveResults.getSelectionIndex();
                 btnBrowse.setEnabled(view.saveTo == 2);
                 btnSave.setEnabled(view.saveTo != 0);
@@ -910,11 +946,13 @@ public class ECContentLarge extends Composite {
         btnBrowse.setText(Messages.getString("ECView.Browse")); //$NON-NLS-1$
         btnBrowse.setEnabled(view.saveTo == 2);
         btnBrowse.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.selectFileLocation();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -923,11 +961,13 @@ public class ECContentLarge extends Composite {
         btnSave.setText(Messages.getString("ECView.SaveNow")); //$NON-NLS-1$
         btnSave.setEnabled(view.saveTo != 0);
         btnSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveLog();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -937,11 +977,13 @@ public class ECContentLarge extends Composite {
         cbAutoSave.setEnabled(view.autoSave);
         cbAutoSave.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cbAutoSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.autoSave = cbAutoSave.getSelection();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Slider;
 import org.eclipse.swt.widgets.Spinner;
+import org.eclipse.swt.widgets.Text;
 import org.jcryptool.core.logging.utils.LogUtil;
 import org.jcryptool.core.util.colors.ColorService;
 import org.jcryptool.core.util.fonts.FontService;
@@ -70,10 +71,10 @@ public class ECContentReal extends Composite {
     private Group groupCurveType = null;
     private Group groupSettings = null;
     private Group groupSave = null;
-    private Label lblCurve = null;
-    private Label lblP = null;
-    private Label lblQ = null;
-    private Label lblR = null;
+    private Text lblCurve = null;
+    private Text lblP = null;
+    private Text lblQ = null;
+    private Text lblR = null;
     private Label lblSaveResults = null;
     private FpPoint pointP;
     private FpPoint pointQ;
@@ -153,7 +154,7 @@ public class ECContentReal extends Composite {
         
         createCanvasCurve();
         
-        lblCurve = new Label(groupCurve, SWT.NONE);
+        lblCurve = new Text(groupCurve, SWT.READ_ONLY);
         lblCurve.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
         lblCurve.setText(""); //$NON-NLS-1$
         
@@ -564,7 +565,7 @@ public class ECContentReal extends Composite {
         groupCalculations.setLayout(new GridLayout(3, false));
         groupCalculations.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));    
 
-        Label label = new Label(groupCalculations, SWT.WRAP);
+        Text label = new Text(groupCalculations, SWT.WRAP | SWT.READ_ONLY);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
         label.setText(Messages.getString("ECContentReal.36")); //$NON-NLS-1$
 
@@ -621,28 +622,28 @@ public class ECContentReal extends Composite {
             }
         });
 
-        label = new Label(groupCalculations, SWT.NONE);
+        label = new Text(groupCalculations, SWT.READ_ONLY);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 3, 1));
         label.setText(Messages.getString("ECContentReal.39")); //$NON-NLS-1$
 
-        label = new Label(groupCalculations, SWT.NONE);
+        label = new Text(groupCalculations, SWT.READ_ONLY);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
         label.setText("P ="); //$NON-NLS-1$
-        lblP = new Label(groupCalculations, SWT.NONE);
+        lblP = new Text(groupCalculations, SWT.READ_ONLY);
         lblP.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
         lblP.setText(""); //$NON-NLS-1$
 
-        label = new Label(groupCalculations, SWT.NONE);
+        label = new Text(groupCalculations, SWT.READ_ONLY);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
         label.setText("Q ="); //$NON-NLS-1$
-        lblQ = new Label(groupCalculations, SWT.NONE);
+        lblQ = new Text(groupCalculations, SWT.READ_ONLY);
         lblQ.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
         lblQ.setText(""); //$NON-NLS-1$
 
-        label = new Label(groupCalculations, SWT.NONE);
+        label = new Text(groupCalculations, SWT.READ_ONLY);
         label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1));
         label.setText("R = P + Q ="); //$NON-NLS-1$
-        lblR = new Label(groupCalculations, SWT.NONE);
+        lblR = new Text(groupCalculations, SWT.READ_ONLY);
         lblR.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
         lblR.setText(""); //$NON-NLS-1$
     }

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Slider;
 import org.eclipse.swt.widgets.Spinner;
 import org.jcryptool.core.logging.utils.LogUtil;
+import org.jcryptool.core.util.colors.ColorService;
 import org.jcryptool.core.util.fonts.FontService;
 import org.jcryptool.visual.ecc.ECCPlugin;
 import org.jcryptool.visual.ecc.Messages;
@@ -53,8 +54,8 @@ public class ECContentReal extends Composite {
     private Button btnSave = null;
     private Canvas canvasCurve = null;
     private Button cbAutoSave = null;
-    private Color black = Display.getCurrent().getSystemColor(SWT.COLOR_BLACK);
-    private Color white = Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
+    private Color black = ColorService.BLACK;
+    private Color white = ColorService.WHITE;
     private Color lightBlue = new Color(this.getDisplay(), 0, 255, 255);
     private Color blue = new Color(this.getDisplay(), 0, 0, 255);
     private Color purple = new Color(this.getDisplay(), 255, 0, 255);
@@ -149,10 +150,13 @@ public class ECContentReal extends Composite {
         groupCurve.setLayout(new GridLayout(3, false));
         groupCurve.setText(Messages.getString("ECContentReal.0")); //$NON-NLS-1$
         groupCurve.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        
         createCanvasCurve();
+        
         lblCurve = new Label(groupCurve, SWT.NONE);
         lblCurve.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
         lblCurve.setText(""); //$NON-NLS-1$
+        
         btnDeletePoints = new Button(groupCurve, SWT.NONE);
         btnDeletePoints.setToolTipText(Messages.getString("ECContentReal.3")); //$NON-NLS-1$
         btnDeletePoints.setText(Messages.getString("ECView.RemoveSelection")); //$NON-NLS-1$
@@ -272,8 +276,9 @@ public class ECContentReal extends Composite {
                     double x = ((e.x - size.x / 2) * (step * 100));
                     double y = -((e.y - size.y / 2) * (step * 100));
                     FpPoint nearestPoint = findNearestPoint(x, y);
-                    if (nearestPoint != null)
+                    if (nearestPoint != null) {
                         setPointSelect(nearestPoint);
+                    }
                 }
             }
         });
@@ -321,8 +326,7 @@ public class ECContentReal extends Composite {
         groupSave.setText(Messages.getString("ECView.SaveResults")); //$NON-NLS-1$
 
         cSaveResults = new Combo(groupSave, SWT.READ_ONLY);
-        cSaveResults
-                .setItems(new String[] {
+        cSaveResults.setItems(new String[] {
                         Messages.getString("ECView.No"), Messages.getString("ECView.ToTextEditor"), Messages.getString("ECView.ToTextFile")}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         cSaveResults.select(view.saveTo);
         cSaveResults.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
@@ -338,8 +342,9 @@ public class ECContentReal extends Composite {
                 btnBrowse.setEnabled(view.saveTo == 2);
                 btnSave.setEnabled(view.saveTo != 0);
                 cbAutoSave.setEnabled(view.saveTo != 0);
-                if (view.saveTo != 0 && view.autoSave)
+                if (view.saveTo != 0 && view.autoSave) {
                     view.saveLog();
+                }
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
         });
@@ -404,6 +409,7 @@ public class ECContentReal extends Composite {
         groupCurveType.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         groupCurveType.setLayout(new GridLayout(3, true));
         groupCurveType.setText(Messages.getString("ECView.SelectCurveType")); //$NON-NLS-1$
+        
         rbtnReal = new Button(groupCurveType, SWT.RADIO);
         rbtnReal.setText(Messages.getString("ECView.RealNumbers")); //$NON-NLS-1$
         rbtnReal.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
@@ -1053,7 +1059,7 @@ public class ECContentReal extends Composite {
                         + (points[i].y - y) * (points[i].y - y));
                 if (currentDistance < minimum) {
                     minimum = currentDistance;
-                    nearestPoint = points[i];
+                    nearestPoint = points[i];      
                 }
             }
         }

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -37,7 +37,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Slider;
 import org.eclipse.swt.widgets.Spinner;
+import org.jcryptool.core.logging.utils.LogUtil;
 import org.jcryptool.core.util.fonts.FontService;
+import org.jcryptool.visual.ecc.ECCPlugin;
 import org.jcryptool.visual.ecc.Messages;
 import org.jcryptool.visual.ecc.algorithm.EC;
 import org.jcryptool.visual.ecc.algorithm.FpPoint;
@@ -116,10 +118,12 @@ public class ECContentReal extends Composite {
         createGroupAttributesR();
 
         Display.getCurrent().asyncExec(new Runnable() {
-            public void run() {
+            @Override
+			public void run() {
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
+                	LogUtil.logError(ECCPlugin.PLUGIN_ID, e);
                 }
                 updateCurve(true);
             }
@@ -155,11 +159,13 @@ public class ECContentReal extends Composite {
         btnDeletePoints.setLayoutData(new GridData(SWT.RIGHT, SWT.FILL, false, false));
         btnDeletePoints.setEnabled(false);
         btnDeletePoints.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 btnPQ.setSelection(true);
                 btnPQ.setEnabled(false);
                 btnKP.setSelection(false);
@@ -181,11 +187,13 @@ public class ECContentReal extends Composite {
         sliderZoom.setMinimum(0);
         sliderZoom.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
         sliderZoom.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 curve.updateCurve(spnrA.getSelection(), spnrB.getSelection(), 50 - sliderZoom
                         .getSelection(), canvasCurve.getSize());
                 points = curve.getPoints();
@@ -211,10 +219,12 @@ public class ECContentReal extends Composite {
         rbtnLarge.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
         rbtnLarge.setText(Messages.getString("ECView.Large")); //$NON-NLS-1$
         rbtnLarge.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.showLarge();
             }
         });
@@ -247,16 +257,18 @@ public class ECContentReal extends Composite {
         GridData gridData = new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1);
         canvasCurve.setLayoutData(gridData);
         canvasCurve.addPaintListener(new PaintListener() {
-            public void paintControl(PaintEvent e) {
+            @Override
+			public void paintControl(PaintEvent e) {
                 drawGraph(e);
             }
         });
         canvasCurve.addMouseMoveListener(new MouseMoveListener() {
-            public void mouseMove(MouseEvent e) {
+            @Override
+			public void mouseMove(MouseEvent e) {
                 Point size = canvasCurve.getSize();
                 if (points != null) {
                     int gridSize = 50 - sliderZoom.getSelection();
-                    double step = Math.pow((double) gridSize, -1);
+                    double step = Math.pow(gridSize, -1);
                     double x = ((e.x - size.x / 2) * (step * 100));
                     double y = -((e.y - size.y / 2) * (step * 100));
                     FpPoint nearestPoint = findNearestPoint(x, y);
@@ -266,7 +278,8 @@ public class ECContentReal extends Composite {
             }
         });
         canvasCurve.addListener(SWT.MouseDown, new Listener() {
-            public void handleEvent(Event event) {
+            @Override
+			public void handleEvent(Event event) {
                 if (pointSelect != null) {
                     if (pointP == null) {
                         setPointP(pointSelect);
@@ -277,10 +290,12 @@ public class ECContentReal extends Composite {
             }
         });
         canvasCurve.addMouseTrackListener(new MouseTrackListener() {
-            public void mouseEnter(MouseEvent e) {
+            @Override
+			public void mouseEnter(MouseEvent e) {
             }
 
-            public void mouseExit(MouseEvent e) {
+            @Override
+			public void mouseExit(MouseEvent e) {
                 pointSelect = null;
                 updateCurve(false);
                 if (pointP == null)
@@ -289,7 +304,8 @@ public class ECContentReal extends Composite {
                     lblQ.setText(""); //$NON-NLS-1$
             }
 
-            public void mouseHover(MouseEvent e) {
+            @Override
+			public void mouseHover(MouseEvent e) {
             }
         });
     }
@@ -311,11 +327,13 @@ public class ECContentReal extends Composite {
         cSaveResults.select(view.saveTo);
         cSaveResults.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cSaveResults.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveTo = cSaveResults.getSelectionIndex();
                 btnBrowse.setEnabled(view.saveTo == 2);
                 btnSave.setEnabled(view.saveTo != 0);
@@ -330,11 +348,13 @@ public class ECContentReal extends Composite {
         btnBrowse.setText(Messages.getString("ECView.Browse")); //$NON-NLS-1$
         btnBrowse.setEnabled(view.saveTo == 2);
         btnBrowse.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.selectFileLocation();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -343,11 +363,13 @@ public class ECContentReal extends Composite {
         btnSave.setText(Messages.getString("ECView.SaveNow")); //$NON-NLS-1$
         btnSave.setEnabled(view.saveTo != 0);
         btnSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.saveLog();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -357,11 +379,13 @@ public class ECContentReal extends Composite {
         cbAutoSave.setEnabled(view.autoSave);
         cbAutoSave.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
         cbAutoSave.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.autoSave = cbAutoSave.getSelection();
                 lblSaveResults.setText(view.saveTo == 2 ? view.getFileName() : ""); //$NON-NLS-1$
             }
@@ -385,11 +409,13 @@ public class ECContentReal extends Composite {
         rbtnReal.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
         rbtnReal.setSelection(true);
         rbtnReal.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.showReal();
             }
 
@@ -399,11 +425,13 @@ public class ECContentReal extends Composite {
         rbtnFP.setSelection(false);
         rbtnFP.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
         rbtnFP.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.showFp();
             }
         });
@@ -412,11 +440,13 @@ public class ECContentReal extends Composite {
         rbtnFM.setSelection(false);
         rbtnFM.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, false));
         rbtnFM.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 view.showFm();
             }
         });
@@ -448,11 +478,13 @@ public class ECContentReal extends Composite {
         spnrA.setSelection(-10);
         spnrA.setMinimum(-100000);
         spnrA.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 btnPQ.setSelection(true);
                 btnKP.setSelection(false);
                 btnPQ.setEnabled(false);
@@ -473,11 +505,13 @@ public class ECContentReal extends Composite {
         spnrB.setSelection(15);
         spnrB.setMinimum(-100000);
         spnrB.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 btnPQ.setSelection(true);
                 btnKP.setSelection(false);
                 btnPQ.setEnabled(false);
@@ -534,11 +568,13 @@ public class ECContentReal extends Composite {
         btnPQ.setSelection(true);
         btnPQ.setEnabled(false);
         btnPQ.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 setPointQ(null);
             }
         });
@@ -548,11 +584,13 @@ public class ECContentReal extends Composite {
         btnKP.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
         btnKP.setEnabled(false);
         btnKP.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 spnrK.setEnabled(btnKP.getSelection());
                 FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
                 setPointQ(q);
@@ -564,11 +602,13 @@ public class ECContentReal extends Composite {
         spnrK.setMinimum(1);
         spnrK.setEnabled(false);
         spnrK.addSelectionListener(new SelectionListener() {
-            public void widgetDefaultSelected(SelectionEvent e) {
+            @Override
+			public void widgetDefaultSelected(SelectionEvent e) {
                 widgetSelected(e);
             }
 
-            public void widgetSelected(SelectionEvent e) {
+            @Override
+			public void widgetSelected(SelectionEvent e) {
                 FpPoint q = curve.multiplyPoint(pointP, spnrK.getSelection());
                 setPointQ(q);
                 updateCurve(false);
@@ -766,7 +806,7 @@ public class ECContentReal extends Composite {
 
         if (points != null) {
             gc.setForeground(blue);
-            double step = Math.pow((double) gridSize, -1);
+            double step = Math.pow(gridSize, -1);
             double x1, y1, x2, y2;
             for (int i = 2; i < points.length; i++) {
                 if (points[i - 2].y == 0) {
@@ -890,7 +930,7 @@ public class ECContentReal extends Composite {
 
                 if (startY < 0) {
                     double alfa = (double) (rX - lX) / (double) (rY - lY);
-                    startX += (double) (-startY) * alfa;
+                    startX += (-startY) * alfa;
                     startY = 0;
                 } else if (startY > size.y) {
                     double alfa = (double) (rX - lX) / (double) (rY - lY);
@@ -900,11 +940,11 @@ public class ECContentReal extends Composite {
 
                 if (endY < 0) {
                     double alfa = (double) (rX - lX) / (double) (rY - lY);
-                    endX += (double) (-endY - 1) * alfa;
+                    endX += (-endY - 1) * alfa;
                     endY = -1;
                 } else if (endY > size.y) {
                     double alfa = (double) (rX - lX) / (double) (rY - lY);
-                    endX -= (double) (endY - size.y) * alfa + 0.5;
+                    endX -= (endY - size.y) * alfa + 0.5;
                     endY = size.y;
                 }
 

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECView.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECView.java
@@ -63,7 +63,8 @@ public class ECView extends ViewPart {
     /**
      * This is a callback that will allow us to create the viewer and initialize it.
      */
-    public void createPartControl(Composite parent) {
+    @Override
+	public void createPartControl(Composite parent) {
         this.parent = parent;
 
         layout = new StackLayout();
@@ -148,7 +149,7 @@ public class ECView extends ViewPart {
 
     private void saveToEditor() {
         if (logFile == null) {
-            logFile = new File(new File(DirectoryService.getTempDir()), "calculations.txt"); //$NON-NLS-1$ //$NON-NLS-2$
+            logFile = new File(new File(DirectoryService.getTempDir()), "calculations.txt"); //$NON-NLS-1$ 
             logFile.deleteOnExit();
         }
 
@@ -202,7 +203,7 @@ public class ECView extends ViewPart {
         FileDialog dialog = new FileDialog(layout.topControl.getShell(), SWT.SAVE);
         dialog.setFilterNames(new String[] {IConstants.TXT_FILTER_NAME, IConstants.ALL_FILTER_NAME});
         dialog.setFilterExtensions(new String[] {IConstants.TXT_FILTER_EXTENSION, IConstants.ALL_FILTER_EXTENSION});
-        dialog.setFilterPath(DirectoryService.getUserHomeDir()); //$NON-NLS-1$
+        dialog.setFilterPath(DirectoryService.getUserHomeDir()); 
         dialog.setFileName("calculations.txt"); //$NON-NLS-1$
         dialog.setOverwrite(true);
         saveLocation = dialog.open();


### PR DESCRIPTION
Fixes the problem that wrong x-values for the points P and Q are displayed near the zeros of the function.

The calculation method has been improved. The x-values are now calculated to 1/1000 of the normal increment and then rounded to 1/100.

In addition, the function in the lower left corner can now be marked with the mouse and copied. The values for P and Q in the group "Calculations" can also be marked and copied.