### PR TITLE
Corrected user explanation of the parameter p

### DIFF
--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
@@ -74,4 +74,4 @@ ECView_InfinityPoint=Fernpunkt O
 ECView_InfinityPointExplanation=Die elliptische Kurve wird von der Geraden durch Punkte P und Q kein drittes mal geschnitten. Punkt R is der Fernpunkt O.
 ECView_ClearQ=Auswahl von Q (per Maus) aufheben
 ECView_PLimit=Limit f\u00fcr den Parameter p
-ECView_PLimitExplanation=Das Limit f\u00fcr den Parameter p ist 1000. F\u00fcr gro\u00dFe Parameter w\u00e4hlen Sie bitte die Ansicht "Curve size Large" (in der Gruppierung "Settings"). Allerdings werden in der Ansicht "Kurvengr\u00f6\u00dFe Gro\u00dF" die Berechnungen nicht mehr visualisiert.
+ECView_PLimitExplanation=Hier gilt f\u00fcr den Parameter p: p <= 1000. F\u00fcr gr\u00f6\u00dFere Parameterwerte w\u00e4hlen Sie bitte in der Gruppierung "Einstellungen" die Ansicht "Kurvengr\u00f6\u00dFe Gro\u00dF". Allerdings werden in der Ansicht "Kurvengr\u00f6\u00dFe Gro\u00dF" die Berechnungen nicht mehr visualisiert.


### PR DESCRIPTION
Corrected the German explanation of the limit for the parameter p.

<img width="1279" alt="Screenshot 2019-05-03 at 09 21 52" src="https://user-images.githubusercontent.com/22661949/57126658-a2262e80-6d85-11e9-8966-495ee9450c7a.png">
