### PR TITLE
ECC Text Changes - How to select P and Q

### DIFF
--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages.properties
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages.properties
@@ -6,12 +6,12 @@ ECContentFm_3=Deselects the highlighted points
 ECContentFm_4=This entry depends on the choice of m and f.
 ECContentFm_40=Show binary values
 ECContentFm_45=Calculations
-ECContentFm_46=Please choose P with your mouse and select how\nto choose Q:
+ECContentFm_46=Please choose P in the graphic with your mouse\nand select how to choose Q via the radio buttons:
 ECContentFm_47=Choose Q also with your mouse.
 ECContentFm_48=Choose Q as k*P with k =
 ECContentFm_49=Results:
 ECContentFp_0=Elliptic Curve (y\u00b2 = (x\u00b3 + ax + b) mod p)
-ECContentFp_1=Please choose P in the graphic with your mouse and\nselect how to choose Q:
+ECContentFp_1=Please choose P in the graphic with your mouse\nand select how to choose Q via the radio buttons:
 ECContentFp_3=Deselects the highlighted points
 ECContentFp_37=Calculations
 ECContentFp_39=Choose Q also with your mouse.
@@ -24,7 +24,7 @@ ECContentLarge_18=Multiply P by k
 ECContentReal_0=Elliptic Curve  (y\u00b2 = x\u00b3 + ax + b)
 ECContentReal_3=Deselects the highlighted points
 ECContentReal_35=Calculations
-ECContentReal_36=Please choose P in the graphic with your mouse\nand select how to choose Q:
+ECContentReal_36=Please choose P in the graphic with your mouse\nand select how to choose Q via the radio buttons:
 ECContentReal_37=Choose Q also with your mouse.
 ECContentReal_38=Choose Q as k*P with k =
 ECContentReal_39=Results:

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/messages_de.properties
@@ -6,12 +6,12 @@ ECContentFm_3=Abw\u00e4hlen der markierten Punkte
 ECContentFm_4=Die Auswahl von b ist abh\u00E4nig von m und f.
 ECContentFm_40=Zeige bin\u00e4re Werte
 ECContentFm_45=Berechnungen
-ECContentFm_46=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die\nMethode f\u00fcr Q:
+ECContentFm_46=Bitte w\u00e4hlen Sie den Punkt P im Graphen mit der Maus und \nw\u00e4hlen Sie die Methode f\u00fcr Q mit dem Radiobutton:
 ECContentFm_47=Q ebenfalls mit der Maus w\u00e4hlen.
 ECContentFm_48=Q ist k*P mit k =
 ECContentFm_49=Ergebnisse:
 ECContentFp_0=Elliptische Kurve (y\u00b2 = (x\u00b3 + ax + b) mod p)
-ECContentFp_1=Bitte w\u00e4hlen Sie P mit der Maus und w\u00e4hlen Sie die\nMethode f\u00fcr Q:
+ECContentFp_1=Bitte w\u00e4hlen Sie den Punkt P im Graphen mit der Maus und \nw\u00e4hlen Sie die Methode f\u00fcr Q mit dem Radiobutton:
 ECContentFp_3=Abw\u00e4hlen der markierten Punkte
 ECContentFp_37=Berechnungen
 ECContentFp_39=Q ebenfalls mit der Maus w\u00e4hlen.
@@ -24,7 +24,7 @@ ECContentLarge_18=P mit k multiplizieren
 ECContentReal_0=Elliptische Kurve  (y\u00b2 = x\u00b3 + ax + b)
 ECContentReal_3=Abw\u00e4hlen der markierten Punkte
 ECContentReal_35=Berechnungen
-ECContentReal_36=Bitte w\u00e4hlen Sie P in der Grafik mit der Maus und\nw\u00e4hlen Sie die Methode f\u00fcr Q:
+ECContentReal_36=Bitte w\u00e4hlen Sie den Punkt P im Graphen mit der Maus und \nw\u00e4hlen Sie die Methode f\u00fcr Q mit dem Radiobutton:
 ECContentReal_37=Q ebenfalls mit der Maus w\u00e4hlen.
 ECContentReal_38=Q ist k*P mit k =
 ECContentReal_39=Ergebnisse:


### PR DESCRIPTION
I updated the text for the ECC plugin detailing how to select P and Q. The German version is based on the comments made during a Telco.

Before:

<img width="393" alt="Screenshot 2019-10-08 at 17 39 15" src="https://user-images.githubusercontent.com/22661949/66415188-f1d2eb00-e9f2-11e9-9ae0-abb6c0254095.png">


After:

<img width="464" alt="Screenshot 2019-10-08 at 17 36 12" src="https://user-images.githubusercontent.com/22661949/66415198-f8f9f900-e9f2-11e9-96a5-a43cc811f098.png">



