### PR TITLE
Updated copyright to 2020.

### DIFF
--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/EntropyPlugin.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/EntropyPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyCalc.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyCalc.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyData.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyTupelFreq.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/calc/EntropyTupelFreq.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUI.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUI.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUIconfig.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUIconfig.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUIresults.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUIresults.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUItable.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/EntropyUItable.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/Messages.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/views/EntropyAnalysisView.java
+++ b/org.jcryptool.analysis.entropy/src/org/jcryptool/analysis/entropy/views/EntropyAnalysisView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.feature/feature.xml
+++ b/org.jcryptool.analysis.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/crypto">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/Activator.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/Activator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/FleissnerWindow.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/FleissnerWindow.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/KeyListener.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/KeyListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/KeyPainter.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/KeyPainter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/LoadFiles.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/LoadFiles.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/Messages.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/OutputDialog.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/UI/OutputDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/handlers/HelpHandler.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/handlers/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/handlers/RestartHandler.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/Grille.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/Grille.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/KeySchablone.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/KeySchablone.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/Schablone.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/key/Schablone.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/CryptedText.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/CryptedText.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/FleissnerGrille.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/FleissnerGrille.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/MethodApplication.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/MethodApplication.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/ParameterSettings.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/ParameterSettings.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/TextValuator.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/logic/TextValuator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/views/SampleView.java
+++ b/org.jcryptool.analysis.fleissner/src/org/jcryptool/analysis/fleissner/views/SampleView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2019, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/FreqAnalysisHelperInterface.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/FreqAnalysisHelperInterface.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/FreqAnalysisPlugin.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/FreqAnalysisPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/IFreqAnalysisAccess.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/IFreqAnalysisAccess.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/calc/FreqAnalysisCalc.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/calc/FreqAnalysisCalc.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/calc/FreqAnalysisData.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/calc/FreqAnalysisData.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/handler/HelpHandler.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/AbstractAnalysisUI.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/AbstractAnalysisUI.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/CustomFreqCanvas.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/CustomFreqCanvas.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FreqAnalysisGraph.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FreqAnalysisGraph.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FreqAnalysisUI.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FreqAnalysisUI.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FullAnalysisUI.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/FullAnalysisUI.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/Messages.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/SimpleAnalysisUI.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/ui/SimpleAnalysisUI.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/views/FreqAnalysisView.java
+++ b/org.jcryptool.analysis.freqanalysis/src/org/jcryptool/analysis/freqanalysis/views/FreqAnalysisView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/FriedmanHelperInterface.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/FriedmanHelperInterface.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/FriedmanPlugin.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/FriedmanPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/IFriedmanAccess.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/IFriedmanAccess.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/calc/FriedmanCalc.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/calc/FriedmanCalc.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/handler/HelpHandler.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/CustomFriedmanCanvas.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/CustomFriedmanCanvas.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraph.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraph.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraphUI.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraphUI.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/MColor.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/MColor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/Messages.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/TextViewer.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/TextViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/views/FriedmanView.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/views/FriedmanView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/Bar.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/Bar.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/Graph.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/Graph.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/MColor.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/MColor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/LabelBar.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/LabelBar.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/OverlayBar.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/OverlayBar.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/OverlayLabelBar.java
+++ b/org.jcryptool.analysis.graphtools/src/org/jcryptool/analysis/graphtools/derivates/OverlayLabelBar.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/Activator.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/Activator.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/DynamicPredefinedStatisticsProvider.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/DynamicPredefinedStatisticsProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/Messages.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/TextStatistic.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/calc/TextStatistic.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/Messages.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/SubstitutionAnalysisConfigPanel.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/SubstitutionAnalysisConfigPanel.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/SubstitutionAnalysisPanel.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/SubstitutionAnalysisPanel.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/IllustrationSubstitutionLetterInputField.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/IllustrationSubstitutionLetterInputField.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/Messages.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/PredefinedStatisticsProvider.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/PredefinedStatisticsProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsDisplayer.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsDisplayer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsSelector.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsSelector.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsWizard.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsWizardPage.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/StatisticsWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstKeyViewer.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstKeyViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionAnalysisText.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionAnalysisText.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionChooser.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionChooser.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionKeyEditor.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionKeyEditor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionLetterInputField.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/ui/modules/utils/SubstitutionLetterInputField.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/Messages.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
+++ b/org.jcryptool.analysis.substitution/src/org/jcryptool/analysis/substitution/views/SubstitutionAnalysisView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.textmodify/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.analysis.textmodify/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.textmodify/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.analysis.textmodify/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/TextmodifyPlugin.java
+++ b/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/TextmodifyPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/commands/Messages.java
+++ b/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/commands/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/commands/TransformHandler.java
+++ b/org.jcryptool.analysis.textmodify/src/org/jcryptool/analysis/textmodify/commands/TransformHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.transpositionanalysis/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.analysis.transpositionanalysis/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.transpositionanalysis/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.analysis.transpositionanalysis/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/TranspositionAnalysisPlugin.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/TranspositionAnalysisPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/Analysis.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/Analysis.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/AnalysisInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/AnalysisInput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/AnalysisOutput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/AnalysisOutput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/PolledPositiveInteger.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/PolledPositiveInteger.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/PolledValue.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/PolledValue.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/TranspositionCalc.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/TranspositionCalc.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/InitializationPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/InitializationPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisCipherlengthDividers.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisCipherlengthDividers.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisDataobject.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisDataobject.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisInitialization.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisInitialization.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisInitializationInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisInitializationInput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisPadding.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisPadding.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisPaddingInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisPaddingInput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisResumee.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/TranspositionAnalysisResumee.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/PolledTranspositionKey.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/PolledTranspositionKey.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysis.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysis.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisConclusion.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisConclusion.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisInput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisOutput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisOutput.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisResultAtom.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/calc/transpositionanalysis/model/TranspositionAnalysisResultAtom.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/handler/HelpHandler.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/handler/RestartHandler.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/handler/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/KeyViewer.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/KeyViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@ package org.jcryptool.analysis.transpositionanalysis.ui;
 
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/Messages.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/ReadDirectionChooser.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/ReadDirectionChooser.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/TranspAnalysisUI.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/TranspAnalysisUI.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/TranspositionTableComposite.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/TranspositionTableComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/Messages.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextModifyPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextModifyPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextWizard.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextWizard.java
@@ -1,4 +1,13 @@
 //-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.analysis.transpositionanalysis.ui.wizards;
 
 import org.eclipse.jface.wizard.Wizard;

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextWizardPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/TranspTextWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@ package org.jcryptool.analysis.transpositionanalysis.ui.wizards;
 
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisSelectItem.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisSelectItem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisWizard.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisWizardIndexPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/AnalysisWizardIndexPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/CalculationPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/CalculationPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/ConclusionItem.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/ConclusionItem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/ConclusionPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/ConclusionPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/DividerAnalysisPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/DividerAnalysisPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/NewAnalysisSelectionPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/NewAnalysisSelectionPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/PaddingAnalysisPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/PaddingAnalysisPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/SingleAnalysisPage.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/autoanalysiswizard/SingleAnalysisPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/Messages.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.analysis.transpositionanalysis.ui.wizards.inputs;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/TextWithSourceInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/TextWithSourceInput.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.analysis.transpositionanalysis.ui.wizards.inputs;
 
 import java.io.File;

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/TextonlyInput.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/ui/wizards/inputs/TextonlyInput.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.analysis.transpositionanalysis.ui.wizards.inputs;
 
 import org.jcryptool.core.util.input.InputVerificationResult;

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/views/Messages.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/views/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.analysis.transpositionanalysis.views;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/views/TranspAnalysisView.java
+++ b/org.jcryptool.analysis.transpositionanalysis/src/org/jcryptool/analysis/transpositionanalysis/views/TranspAnalysisView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/VigenereBreakerPlugin.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/VigenereBreakerPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/IllegalActionException.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/IllegalActionException.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/IllegalInputException.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/IllegalInputException.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/NoContentException.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/exceptions/NoContentException.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/DataProvider.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/DataProvider.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
  * ***************************************************************************

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyCalcAdapter.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyCalcAdapter.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyData.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyData.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyGraphAdapter.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FrequencyGraphAdapter.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanCalcAdapter.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanCalcAdapter.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanData.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanData.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanGraphAdapter.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/FriedmanGraphAdapter.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/LetterFrequency.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/LetterFrequency.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/Messages.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/interfaces/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/Content.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/Content.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/ContentDelegator.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/ContentDelegator.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/DecryptionGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/DecryptionGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
  * ***************************************************************************

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FrequencyContainer.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FrequencyContainer.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FrequencyGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FrequencyGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
  * ***************************************************************************

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FriedmanContainer.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FriedmanContainer.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FriedmanGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/FriedmanGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
  * ***************************************************************************

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/Messages.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/OptionsDialogGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/OptionsDialogGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordContainer.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordContainer.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordDialogGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordDialogGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordElementGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/PasswordElementGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/QuickDecryptGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/QuickDecryptGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
  * ***************************************************************************

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/SummaryGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/SummaryGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/VigenereBreakerGui.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/ui/VigenereBreakerGui.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License

--- a/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/views/VigenereBreakerView.java
+++ b/org.jcryptool.analysis.vigenere/src/org/jcryptool/analysis/vigenere/views/VigenereBreakerView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/ViterbiPlugin.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/ViterbiPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/BitwiseXOR.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/BitwiseXOR.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Combination.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Combination.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/IO.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/IO.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/LanguageModel.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/LanguageModel.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/ModularAddition.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/ModularAddition.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/NGramGen.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/NGramGen.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/NGramProvider.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/NGramProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Path.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Path.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Viterbi.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/Viterbi.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/ViterbiObserver.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/algorithm/ViterbiObserver.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/handlers/RestartHandler.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.analysis.viterbi.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/DetailsComposite.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/DetailsComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/Messages.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/ViterbiComposite.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/ViterbiComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/ViterbiView.java
+++ b/org.jcryptool.analysis.viterbi/src/org/jcryptool/analysis/viterbi/views/ViterbiView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.analysis/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.analysis/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.analysis/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/AdfgvxPlugin.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/AdfgvxPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithm.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxCmd.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxCmd.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxEngine.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxFactory.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/AdfgvxFactory.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/AdfgvxWizard.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/AdfgvxWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/AdfgvxWizardPage.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/AdfgvxWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.adfgvx/src/org/jcryptool/crypto/classic/adfgvx/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/Alphabet.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/Alphabet.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/AlphabetsPlugin.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/AlphabetsPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/AtomAlphabet.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/AtomAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.composite;
 
 import java.util.HashMap;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/CompositeAlphabet.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/CompositeAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/ExcludeCharAlphabet.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/ExcludeCharAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/StringAlphabetFactory.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/composite/StringAlphabetFactory.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/AlphabetsPreferencePage.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/AlphabetsPreferencePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/AlphabetsPreferencesInitializer.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/AlphabetsPreferencesInitializer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/Messages.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.preferences;
 
 import java.util.MissingResourceException;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/MyPreference.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/MyPreference.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/TransformationPreferenceSet.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/TransformationPreferenceSet.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/TransformationsPreferencePage.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/preferences/TransformationsPreferencePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphaFileOutOfDateException.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphaFileOutOfDateException.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.tools;
 
 public class AlphaFileOutOfDateException extends Exception {

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphabetPersistence.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphabetPersistence.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphabetStore.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/AlphabetStore.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/Messages.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/tools/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.tools;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/AddAlphabetWizard.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/AddAlphabetWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/EditAlphabetWizard.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/EditAlphabetWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/EditAlphabetWizardPage.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/EditAlphabetWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.alphabets/src/org/jcryptool/crypto/classic/alphabets/ui/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.alphabets.ui;
 
 import java.util.MissingResourceException;

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/AutoVigenerePlugin.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/AutoVigenerePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/AutovigenereCmd.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/AutovigenereCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithm.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereEngine.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/AutoVigenereEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/AutoVigenereWizard.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/AutoVigenereWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/AutoVigenereWizardPage.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/AutoVigenereWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.autovigenere/src/org/jcryptool/crypto/classic/autovigenere/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.crypto.classic.caesar/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.crypto.classic.caesar/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/CaesarPlugin.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/CaesarPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithm.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithmHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarCmd.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarCmd.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarEngine.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/CaesarEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/CaesarWizard.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/CaesarWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/CaesarWizardPage.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/CaesarWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.caesar/src/org/jcryptool/crypto/classic/caesar/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/DelastelleCmd.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/DelastelleCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/DelastellePlugin.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/DelastellePlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithm.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleEngine.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/DelastelleEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/DelastelleWizard.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/DelastelleWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/DelastelleWizardPage.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/DelastelleWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.delastelle/src/org/jcryptool/crypto/classic/delastelle/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/DoppelkastenPlugin.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/DoppelkastenPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithm.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenCmd.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenEngine.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/DoppelkastenEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/DoppelkastenWizard.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/DoppelkastenWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/DoppelkastenWizardPage.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/DoppelkastenWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.doppelkasten/src/org/jcryptool/crypto/classic/doppelkasten/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.feature/feature.xml
+++ b/org.jcryptool.crypto.classic.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/crypto">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ClassicCryptoModelPlugin.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ClassicCryptoModelPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/ClassicAlgorithmCmd.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/ClassicAlgorithmCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/ClassicAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/ClassicAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/InputVerificationResultKeyNotInAlphabet.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/InputVerificationResultKeyNotInAlphabet.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithm/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithmconfig/ShowAlgorithmConfigAction.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/algorithmconfig/ShowAlgorithmConfigAction.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicCryptoPage.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicCryptoPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicTransformationPage.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicTransformationPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicWizard.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/AbstractClassicWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/KeyInput.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/KeyInput.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/Messages.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/util/MWizardMessage.java
+++ b/org.jcryptool.crypto.classic.model/src/org/jcryptool/crypto/classic/model/ui/wizard/util/MWizardMessage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/PlayfairPlugin.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/PlayfairPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithm.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairCmd.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairEngine.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/algorithm/PlayfairEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/PlayfairWizard.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/PlayfairWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/PlayfairWizardPage.java
+++ b/org.jcryptool.crypto.classic.playfair/src/org/jcryptool/crypto/classic/playfair/ui/PlayfairWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/SubstitutionPlugin.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/SubstitutionPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithm.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionCommand.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionCommand.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionEngine.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/algorithm/SubstitutionEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/SubstitutionWizard.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/SubstitutionWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/SubstitutionWizardPage.java
+++ b/org.jcryptool.crypto.classic.substitution/src/org/jcryptool/crypto/classic/substitution/ui/SubstitutionWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/TranspositionPlugin.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/TranspositionPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithm.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmCmd.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmCmd.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionEngine.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionKey.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionKey.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionTable.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/algorithm/TranspositionTable.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionKeyInputComposite.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionKeyInputComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionWizard.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionWizardPage.java
+++ b/org.jcryptool.crypto.classic.transposition/src/org/jcryptool/crypto/classic/transposition/ui/TranspositionWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/VigenerePlugin.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/VigenerePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithm.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithmHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereCmd.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereCmd.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereEngine.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/algorithm/VigenereEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/IClassicUIKey.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/IClassicUIKey.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/VigenereWizard.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/VigenereWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/VigenereWizardPage.java
+++ b/org.jcryptool.crypto.classic.vigenere/src/org/jcryptool/crypto/classic/vigenere/ui/VigenereWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/XorPlugin.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/XorPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/FileTransferManager.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/FileTransferManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/Messages.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XORConfiguration.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XORConfiguration.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.classic.xor.algorithm;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithm.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithmHandler.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithmSpecification.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorAlgorithmSpecification.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorCmd.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorCmd.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorEngine.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/algorithm/XorEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/FilechooserComposite.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/FilechooserComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/Messages.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/XorWizard.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/XorWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/XorWizardPage.java
+++ b/org.jcryptool.crypto.classic.xor/src/org/jcryptool/crypto/classic/xor/ui/XorWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.classic/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.crypto.classic/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.classic/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.crypto.classic/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.feature/feature.xml
+++ b/org.jcryptool.crypto.modern.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/crypto">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/SHA3Plugin.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/SHA3Plugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOAction.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOAction.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOAlgorithm.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOHashState.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/echo/ECHOHashState.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHAction.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHAction.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHAlgorithm.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHHashState.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/jh/JHHashState.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/Skein512.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/Skein512.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/Skein512Small.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/Skein512Small.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinAction.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinAction.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinAlgorithm.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinUbi64.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinUbi64.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinUtil.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/algorithm/SkeinUtil.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/threefish/ThreefishImpl.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/threefish/ThreefishImpl.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/threefish/ThreefishSecretKey.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/skein/threefish/ThreefishSecretKey.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/Messages.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/SHA3Wizard.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/SHA3Wizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/SHA3WizardPage.java
+++ b/org.jcryptool.crypto.modern.sha3/src/org/jcryptool/crypto/modern/sha3/ui/SHA3WizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/Arc4Plugin.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/Arc4Plugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4Algorithm.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4Algorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4AlgorithmHandler.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4AlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4Engine.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Arc4Engine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/algorithm/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Arc4Wizard.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Arc4Wizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Arc4WizardPage.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Arc4WizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.arc4/src/org/jcryptool/crypto/modern/stream/arc4/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/DragonPlugin.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/DragonPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonAlgorithm.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonAlgorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonAlgorithmHandler.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonAlgorithmHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonEngine.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonKeyStreamGenerator.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/DragonKeyStreamGenerator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/algorithm/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/DragonWizard.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/DragonWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/DragonWizardPage.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/DragonWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.dragon/src/org/jcryptool/crypto/modern/stream/dragon/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/LfsrPlugin.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/LfsrPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrAlgorithm.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrAlgorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrAlgorithmHandler.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrAlgorithmHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2010, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrEngine.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrKeyStreamGenerator.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/LfsrKeyStreamGenerator.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/algorithm/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/LfsrWizard.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/LfsrWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/LfsrWizardPage.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/LfsrWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/Messages.java
+++ b/org.jcryptool.crypto.modern.stream.lfsr/src/org/jcryptool/crypto/modern/stream/lfsr/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/CryptoUIPlugin.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/CryptoUIPlugin.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui;
 
 import org.eclipse.jface.resource.ImageRegistry;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/AlphabetManualInputField.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/AlphabetManualInputField.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/AlphabetSelectorComposite.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/AlphabetSelectorComposite.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets;
 
 import java.util.Collection;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets;
 
 import java.util.MissingResourceException;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/BlockAlphabet.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/BlockAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 import org.jcryptool.core.operations.alphabets.AbstractAlphabet;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/ExcludeCharBlock.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/ExcludeCharBlock.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 import java.util.List;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/HasOriginalBlockAlpha.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/HasOriginalBlockAlpha.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 public interface HasOriginalBlockAlpha {

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/NewAlphabetBlockWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/NewAlphabetBlockWizard.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 import org.eclipse.jface.wizard.Wizard;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/NewAlphabetBlockWizardPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/NewAlphabetBlockWizardPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 import java.util.Observable;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/RangeBlockAlphabet.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/RangeBlockAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 public class RangeBlockAlphabet extends BlockAlphabet {

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/RevertBlock.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/RevertBlock.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks;
 
 import org.jcryptool.core.operations.alphabets.AbstractAlphabet;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/paramselectionui/LeaveOutCharSelectorWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/paramselectionui/LeaveOutCharSelectorWizard.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks.paramselectionui;
 
 import org.eclipse.jface.wizard.Wizard;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/paramselectionui/LeaveOutCharSelectorWizardPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/alphabetblocks/paramselectionui/LeaveOutCharSelectorWizardPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.alphabetblocks.paramselectionui;
 
 import org.eclipse.jface.wizard.WizardPage;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/AtomAlphabet.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/AtomAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/CompositeAlphabet.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/CompositeAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/ExcludeCharAlphabet.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/ExcludeCharAlphabet.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/StringAlphabetFactory.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/StringAlphabetFactory.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.composite;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/Test.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/composite/Test.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.composite;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/ComposeAlphabetComposite.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/ComposeAlphabetComposite.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets;
 
 import java.util.Arrays;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CreateCustomAlphabetIntroPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CreateCustomAlphabetIntroPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CreateCustomAlphabetsWizardPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CreateCustomAlphabetsWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CustomAlphabetWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/CustomAlphabetWizard.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets;
 
 import org.eclipse.jface.wizard.IWizardPage;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/ShowAlphaContentWindow.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/ShowAlphaContentWindow.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/CustomAlphabetHistoryManager.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/CustomAlphabetHistoryManager.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets.customhistory;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/CustomAlphabetItem.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/CustomAlphabetItem.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets.customhistory;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/alphabets/customalphabets/customhistory/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.alphabets.customalphabets.customhistory;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/CharsToNumbersComposite.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/CharsToNumbersComposite.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.text.MessageFormat;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/CompositeNumberInput.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/CompositeNumberInput.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.text.MessageFormat;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/ConversionCharsToNumbers.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/ConversionCharsToNumbers.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/ConversionNumbersToBlocks.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/ConversionNumbersToBlocks.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.List;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----s
 package org.jcryptool.crypto.ui.textblockloader;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/NumberblocksAndTextViewer.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/NumberblocksAndTextViewer.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.HashMap;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/Repr.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/Repr.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 public enum Repr {

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLBlockConversionPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLBlockConversionPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.text.MessageFormat;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLNumberLoaderPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLNumberLoaderPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.List;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLOriginChooserPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLOriginChooserPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import org.eclipse.jface.wizard.WizardPage;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLTextPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TANLTextPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.Observable;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TextAsNumbersLoaderWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/TextAsNumbersLoaderWizard.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader;
 
 import java.util.List;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/AlphabetCharsToNumbers.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/AlphabetCharsToNumbers.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader.conversion;
 
 import org.jcryptool.core.operations.alphabets.AbstractAlphabet;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/ConversionStringToBlocks.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/ConversionStringToBlocks.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader.conversion;
 
 import java.util.List;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/NumbersToBlocksConversion.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textblockloader/conversion/NumbersToBlocksConversion.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textblockloader.conversion;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/ControlHatcher.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/ControlHatcher.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/TextTransformationDisplayer.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/TextTransformationDisplayer.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/TextLoadController.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/TextLoadController.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard;
 
 import java.util.LinkedList;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/LoadTextWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/LoadTextWizard.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard.loadtext;
 
 import org.eclipse.jface.wizard.Wizard;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/LoadTextWizardPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/LoadTextWizardPage.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard.loadtext;
 
 import java.io.File;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard.loadtext;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/TextonlyInput.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/TextonlyInput.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard.loadtext;
 
 import org.jcryptool.core.util.input.InputVerificationResult;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/TranspTextModifyPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/TranspTextModifyPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/UIInputTextWithSource.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textloader/ui/wizard/loadtext/UIInputTextWithSource.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textloader.ui.wizard.loadtext;
 
 import java.io.File;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifySelectionComposite.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifySelectionComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifyWizard.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifyWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifyWizardPage.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/ModifyWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/PreviewViewer.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/PreviewViewer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/WizardData.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textmodify/wizard/WizardData.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textsource;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextInputWithSource.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextInputWithSource.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textsource;
 
 import java.io.File;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextInputWithSourceDisplayer.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextInputWithSourceDisplayer.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textsource;
 
 import java.io.File;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextSourceType.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/textsource/TextSourceType.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.textsource;
 
 /**

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/Messages.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/Messages.java
@@ -2,7 +2,7 @@ package org.jcryptool.crypto.ui.util;
 
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/NestedEnable.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/NestedEnable.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.util;
 
 import java.util.IdentityHashMap;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/NestedEnableDisableSwitcher.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/NestedEnableDisableSwitcher.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.crypto.ui.util;
 
 import org.eclipse.swt.widgets.Control;

--- a/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/WidgetBubbleUIInputHandler.java
+++ b/org.jcryptool.crypto.ui/src/org/jcryptool/crypto/ui/util/WidgetBubbleUIInputHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/DividePlugin.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/DividePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/ChoosePlayerDialog.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/ChoosePlayerDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/Messages.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/SaveRecordConfirmation.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/dialogs/SaveRecordConfirmation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/HelpHandler.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/NewGameHandler.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/NewGameHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/RedoHandler.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/RedoHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/SaveGameHandler.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/SaveGameHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/UndoHandler.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/handler/UndoHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/ComputerPlayer.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/ComputerPlayer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachine.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachineEvent.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachineEvent.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachineNotifyEvent.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameMachineNotifyEvent.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameState.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/GameState.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/HumanPlayer.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/HumanPlayer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IMathEngine.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IMathEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IPlayer.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IPlayer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IStrategy.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/IStrategy.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/LowestStrategy.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/LowestStrategy.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/RandomStrategy.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/RandomStrategy.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/TrivialMathEngine.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/logic/TrivialMathEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/MenuBarActivation.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/MenuBarActivation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/NewGameStateSourceProvider.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/NewGameStateSourceProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/RedoSourceProvider.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/RedoSourceProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/SaveStateSourceProvider.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/SaveStateSourceProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/UndoSourceProvider.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/sourceProviders/UndoSourceProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/util/DividerGameUtil.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/util/DividerGameUtil.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/views/DivideView.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/views/DivideView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.divide/src/org/jcryptool/games/divide/views/Messages.java
+++ b/org.jcryptool.games.divide/src/org/jcryptool/games/divide/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.feature/feature.xml
+++ b/org.jcryptool.games.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/crypto">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/NumberSharkPlugin.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/NumberSharkPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/EndOfGameDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/EndOfGameDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/Messages.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/NewGameDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/dialogs/NewGameDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HelpHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HeuristicStrategyHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HeuristicStrategyHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HintHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/HintHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/Messages.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/NewGameHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/NewGameHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/OptimalStrategyHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/OptimalStrategyHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/RedoHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/RedoHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/SharkMealHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/SharkMealHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/UndoHandler.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/handler/UndoHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/AbstractResultDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/AbstractResultDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/AbstractStrategyDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/AbstractStrategyDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/CalculationThread.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/CalculationThread.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/HeuristicStrategyDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/HeuristicStrategyDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/MaximizeStrategy.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/MaximizeStrategy.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/Messages.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/OptimalStrategyDialog.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/OptimalStrategyDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ResultDialHeuristicStrategy.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ResultDialHeuristicStrategy.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ResultDialOptimalStrategy.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ResultDialOptimalStrategy.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/Schu1Strategy.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/Schu1Strategy.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/VanNekStrategy.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/VanNekStrategy.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ZahlenhaiBestwerte.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/strategies/ZahlenhaiBestwerte.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CSVConverter.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CSVConverter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CommandState.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CommandState.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CommandStateChanger.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/CommandStateChanger.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/ScoreTableRow.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/util/ScoreTableRow.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/Messages.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/Number.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/Number.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberField.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberField.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberSharkView.java
+++ b/org.jcryptool.games.numbershark/src/org/jcryptool/games/numbershark/views/NumberSharkView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/Messages.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/SudokuPlugin.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/SudokuPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/Area.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/Area.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/KillerPuzzle.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/KillerPuzzle.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/NormalPuzzle.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/NormalPuzzle.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuView.java
+++ b/org.jcryptool.games.sudoku/src/org/jcryptool/games/sudoku/views/SudokuView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Card.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Card.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/CardStack.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/CardStack.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Field.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Field.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/GenericRoundedButton.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/GenericRoundedButton.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Sudoku.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Sudoku.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/SudokuField.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/SudokuField.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/SupplyStack.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/SupplyStack.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/VerificationPanel.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/VerificationPanel.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Zudoku.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/Zudoku.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/ZudokuConfig.java
+++ b/org.jcryptool.games.zudoku/src/edu/kit/iks/zudoku/ZudokuConfig.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/ZudokuPlugin.java
+++ b/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/ZudokuPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/handler/HelpHandler.java
+++ b/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/handler/NewGameHandler.java
+++ b/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/handler/NewGameHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/views/Messages.java
+++ b/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/views/ZudokuView.java
+++ b/org.jcryptool.games.zudoku/src/org/jcryptool/games/zudoku/views/ZudokuView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.games/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.games/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.games/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.games/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/ACOPlugin.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/ACOPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColAnalysisController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColAnalysisController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.jcryptool.visual.aco.model.CommonModel;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColConfigController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColConfigController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.eclipse.jface.window.Window;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColDescriptionController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColDescriptionController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.jcryptool.visual.aco.model.CommonModel;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColEventController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColEventController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import java.util.ArrayList;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColEvents.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColEvents.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 public interface AntColEvents{

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColGraphController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColGraphController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.jcryptool.visual.aco.model.CommonModel;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColPherMatrixController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColPherMatrixController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.jcryptool.visual.aco.model.CommonModel;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColResultController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColResultController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import java.util.Vector;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColVisualController.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/controller/AntColVisualController.java
@@ -1,3 +1,13 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
 package org.jcryptool.visual.aco.controller;
 
 import org.eclipse.swt.widgets.Composite;

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.aco.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/ACO.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/ACO.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/AntModel.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/AntModel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/CommonModel.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/CommonModel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/GraphModel.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/GraphModel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/Messages.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/PseudoRandomChars.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/model/PseudoRandomChars.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColDescriptionComposite.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColDescriptionComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColPherMatrixComposite.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColPherMatrixComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColView.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/AntColView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/Messages.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/view/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/Messages.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/TranspTextModifyPage.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/TranspTextModifyPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/TranspTextWizardPage.java
+++ b/org.jcryptool.visual.aco/src/org/jcryptool/visual/aco/wizard/TranspTextWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@ package org.jcryptool.visual.aco.wizard;
 
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.arc4/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.arc4/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.arc4/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4Con.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4Con.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4View.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4View.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4Visual.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ARC4Visual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/Messages.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/ARC4Algorithm.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/ARC4Algorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/AlgARC4.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/AlgARC4.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/AlgSpritz.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/algorithm/AlgSpritz.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/ARC4Composite.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/ARC4Composite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/DatavectorVisual.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/DatavectorVisual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/InstructionVisual.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/InstructionVisual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/VariablesVisual.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/VariablesVisual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/VectorVisual.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/ui/VectorVisual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/wizard/ARC4Wizard.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/wizard/ARC4Wizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/wizard/ARC4WizardPage.java
+++ b/org.jcryptool.visual.arc4/src/org/jcryptool/visual/arc4/wizard/ARC4WizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/AndroidUnlockPatternPlugin.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/AndroidUnlockPatternPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/handlers/HelpHandler.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/handlers/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/AupView.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/AupView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/Backend.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/Backend.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/Messages.java
+++ b/org.jcryptool.visual.aup/src/org/jcryptool/visual/aup/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/algorithm/BabystepGiantstep.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/algorithm/BabystepGiantstep.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/BabystepGiantstepView.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/BabystepGiantstepView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Constants.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Constants.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Messages.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Parameter.java
+++ b/org.jcryptool.visual.babystepgiantstep/src/org/jcryptool/visual/babystepgiantstep/views/Parameter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/ChineseRemainderTheoremPlugin.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/ChineseRemainderTheoremPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/algorithm/ChineseRemainderTheorem.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/algorithm/ChineseRemainderTheorem.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/export/FileExporter.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/export/FileExporter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.crt.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CRTGroup.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CRTGroup.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CheckingEquationDialog.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/CheckingEquationDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/ChineseRemainderTheoremView.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/ChineseRemainderTheoremView.java
@@ -1,9 +1,9 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
- * 
- * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
- * Public License v1.0 which accompanies this distribution, and is available at
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 // -----END DISCLAIMER-----

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Constants.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Constants.java
@@ -1,6 +1,12 @@
-/**
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
- */
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.crt.views;
 
 /**

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Equation.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Equation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Equations.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Equations.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Messages.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/xeuclid/XEuclid.java
+++ b/org.jcryptool.visual.crt/src/org/jcryptool/visual/crt/xeuclid/XEuclid.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/Activator.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/Activator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/CertPathVerifier.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/CertPathVerifier.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/KeystoreConnector.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/KeystoreConnector.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/Messages.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/verification/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCert.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCert.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCertComposite.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCertComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCertPage.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/ChooseCertPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerView.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerViewComposite.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerViewComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerViewController.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/CrtVerViewController.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/Messages.java
+++ b/org.jcryptool.visual.crtVerification/src/org/jcryptool/visual/crtverification/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.des/src/org/jcryptool/visual/des/algorithm/DESController.java
+++ b/org.jcryptool.visual.des/src/org/jcryptool/visual/des/algorithm/DESController.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.des.algorithm;
 
 import java.util.ArrayList;

--- a/org.jcryptool.visual.des/src/org/jcryptool/visual/des/algorithm/DESModel.java
+++ b/org.jcryptool.visual.des/src/org/jcryptool/visual/des/algorithm/DESModel.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.des.algorithm;
 
 import java.util.Random;

--- a/org.jcryptool.visual.des/src/org/jcryptool/visual/des/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.des/src/org/jcryptool/visual/des/handlers/RestartHandler.java
@@ -1,14 +1,13 @@
-package org.jcryptool.visual.des.handlers;
-
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 // -----END DISCLAIMER-----
+package org.jcryptool.visual.des.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;

--- a/org.jcryptool.visual.des/src/org/jcryptool/visual/des/view/DesView.java
+++ b/org.jcryptool.visual.des/src/org/jcryptool/visual/des/view/DesView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.des.view;
 
 import java.text.DateFormat;

--- a/org.jcryptool.visual.des/src/org/jcryptool/visual/des/view/Messages.java
+++ b/org.jcryptool.visual.des/src/org/jcryptool/visual/des/view/Messages.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.des.view;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ECCPlugin.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ECCPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/Messages.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/EC.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/ECFp.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/FmPoint.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/FmPoint.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/FpPoint.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/FpPoint.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/LargeCurves.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/algorithm/LargeCurves.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.ecc.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentFp.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentLarge.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECContentReal.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECView.java
+++ b/org.jcryptool.visual.ecc/src/org/jcryptool/visual/ecc/ui/ECView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ECDHPlugin.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ECDHPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/Messages.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/EC.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/EC.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECFm.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECFm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECFp.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECFp.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECPoint.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/ECPoint.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/LargeCurves.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/algorithm/LargeCurves.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/data/Curves.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/data/Curves.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/Animation.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/Animation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/ECDHComposite.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/ECDHComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/ECDHView.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/view/ECDHView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersComposite.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersWizard.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersWizardPage.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/PublicParametersWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyComposite.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyWizard.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyWizardPage.java
+++ b/org.jcryptool.visual.ecdh/src/org/jcryptool/visual/ECDH/ui/wizards/SecretKeyWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.elGamal/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.elGamal/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ElGamalData.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ElGamalData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/Messages.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/handlers/HelpHandler.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/handlers/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.elGamal.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/ElGamalView.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/ElGamalView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/KeySelectionWizard.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/KeySelectionWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/PlaintextforSignatureVerificationWizard.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/PlaintextforSignatureVerificationWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/TextEntryWizard.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/TextEntryWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/UniqueKeyWizard.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/UniqueKeyWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/ChooseBPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/ChooseBPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/ChooseKPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/ChooseKPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterCiphertextPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterCiphertextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterPlaintextPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterPlaintextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterSignaturePage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/EnterSignaturePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/LoadKeypairPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/LoadKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/LoadPublicKeyPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/LoadPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewChooseKeyTypePage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewChooseKeyTypePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewKeypairPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewPublicKeyPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/NewPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SaveKeypairPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SaveKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SavePublicKeyPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SavePublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SaveWizardPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/SaveWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/TextWizardPage.java
+++ b/org.jcryptool.visual.elGamal/src/org/jcryptool/visual/elGamal/ui/wizards/wizardpages/TextWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/EuclidPlugin.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/EuclidPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/FileExporter.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/FileExporter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/ImageBuffer.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/ImageBuffer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/Messages.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/View.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/View.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/handler/RestartHandler.java
+++ b/org.jcryptool.visual.euclid/src/org/jcryptool/visual/euclid/handler/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/Activator.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/Activator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ExtendedRSA_Visual.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ExtendedRSA_Visual.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ExtendedTabFolder.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ExtendedTabFolder.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/Identity.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/Identity.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/IdentityManager.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/IdentityManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/RsaImplementation.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/RsaImplementation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/SecureMessage.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/SecureMessage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/DeleteIdentityWizard.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/DeleteIdentityWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/ManageVisibleIdentitesWizard.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/ManageVisibleIdentitesWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/NewIdentityWizard.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/NewIdentityWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/DeleteIdentityPage.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/DeleteIdentityPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/ManageVisibleIdentitiesPage.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/ManageVisibleIdentitiesPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/NewIdentityPage.java
+++ b/org.jcryptool.visual.extendedrsa/src/org/jcryptool/visual/extendedrsa/ui/wizards/wizardpages/NewIdentityPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.feature/feature.xml
+++ b/org.jcryptool.visual.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/crypto">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/GrillePlugin.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/GrillePlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/Grille.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/Grille.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/KeySchablone.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/KeySchablone.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/Schablone.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/algorithm/Schablone.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/handlers/HelpHandler.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/handlers/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/Demonstration.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/Demonstration.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/DemonstrationPainter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/KeyListener.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/KeyListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/KeyPainter.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/KeyPainter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/Messages.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
+++ b/org.jcryptool.visual.grille/src/org/jcryptool/visual/grille/ui/View.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/HashingPlugin.java
+++ b/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/HashingPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/algorithms/HashFunction.java
+++ b/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/algorithms/HashFunction.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/views/HashingView.java
+++ b/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/views/HashingView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/views/Messages.java
+++ b/org.jcryptool.visual.hashing/src/org/jcryptool/visual/hashing/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/HEPlugin.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/HEPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/Messages.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/FHEParams.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/FHEParams.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Functions.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Functions.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHData.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHDecrypt.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHDecrypt.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHEncrypt.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHEncrypt.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHKeyGen.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHKeyGen.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHKeyPair.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHKeyPair.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHReCrypt.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/GHReCrypt.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Paillier.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Paillier.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/PaillierData.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/PaillierData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Polynomial.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/Polynomial.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/RSAData.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/algo/RSAData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.he.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/rsa/RSAData.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/rsa/RSAData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/FileCrypto.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/FileCrypto.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/HEComposite.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/HEComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/HEView.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/ui/HEView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHInitialTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHInitialTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHKeySelectionWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHKeySelectionWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHOperationTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/GHOperationTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierInitialTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierInitialTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierKeySelectionWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierKeySelectionWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierOperationTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/PaillierOperationTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAInitialTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAInitialTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAKeySelectionWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAKeySelectionWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAOperationTextWizard.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/RSAOperationTextWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseInitialTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseInitialTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseKeySelGenPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseKeySelGenPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseModulusPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseModulusPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseOperationTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHChooseOperationTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHLoadKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHLoadKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHNewKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHNewKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHSettingsPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/GHSettingsPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseInitialTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseInitialTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseKeySelGenPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseKeySelGenPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseOperationTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierChooseOperationTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierLoadKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierLoadKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierNewKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/PaillierNewKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseInitialTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseInitialTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseKeytypePage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseKeytypePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseOperationTextPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAChooseOperationTextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSADecryptSignPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSADecryptSignPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAEncryptVerifyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSAEncryptVerifyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSALoadKeypairPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSALoadKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSALoadPublicKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSALoadPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSANewKeypairPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSANewKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSANewPublicKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSANewPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASaveKeypairPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASaveKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASavePublicKeyPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASavePublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASaveWizardPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/RSASaveWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/TextWizardPage.java
+++ b/org.jcryptool.visual.he/src/org/jcryptool/visual/he/wizards/pages/TextWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/HuffmanCodingPlugin.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/HuffmanCodingPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/BitString.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/BitString.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/Huffman.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/Huffman.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/InvalidCharacterException.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/InvalidCharacterException.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/Node.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/algorithm/Node.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/handlers/ChangeLayout.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/handlers/ChangeLayout.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/HuffmanCodingView.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/HuffmanCodingView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/Messages.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/ZestLabelProvider.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/ZestLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/ZestNodeContentProvider.java
+++ b/org.jcryptool.visual.huffmanCoding/src/org/jcryptool/visual/huffmanCoding/views/ZestNodeContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Activator.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Activator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CRLEntry.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CRLEntry.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CSR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CSR.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CertificateCSRR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/CertificateCSRR.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/RR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/RR.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/RegistrarCSR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/RegistrarCSR.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/Signature.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateClasses/Signature.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/ShowReq.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/ShowReq.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/Views.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/CertificateViews/Views.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/JCTCA_Visual.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/ShowCSR.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/VerifyIdentity.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/VerifyIdentity.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/Views.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/RegistrarViews/Views.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/ResizeHelper.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/ResizeHelper.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/ShowSigData.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/ShowSigData.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/Views.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/SecondUserViews/Views.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/CreateCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/CreateCert.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/ShowCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/ShowCert.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/SignCert.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/SignCert.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/Views.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/Views.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/dialogs/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/dialogs/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/dialogs/RevokeCertDialog.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/UserViews/dialogs/RevokeCertDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Util.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/Util.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CAListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CAListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CSRListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CSRListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CreateCertListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/CreateCertListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/PluginBtnListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/PluginBtnListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/PubKeyListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/PubKeyListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/RadioButtonListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/RadioButtonListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/ResizeListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/ResizeListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/RevokeButtonListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/RevokeButtonListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SecondUserListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SecondUserListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SelectFileListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SelectFileListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SideBarListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SigVisPluginOpenListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/SigVisPluginOpenListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/TabItemListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/TabItemListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/UserShowCertsListener.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/listeners/UserShowCertsListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/notifiers/SignatureNotifier.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/notifiers/SignatureNotifier.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/CertificationTab.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/Messages.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/RegistrationTab.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/SecondUserTab.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
+++ b/org.jcryptool.visual.jctca/src/org/jcryptool/visual/jctca/tabs/UserTab.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/KleptographyPlugin.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/KleptographyPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/Kleptography.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/Kleptography.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAAttack.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAAttack.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAFunctions.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAFunctions.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAMain.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/algorithm/RSAMain.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.kleptography.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/KleptoView.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/KleptoView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/Messages.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/OverwriteDialog.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/OverwriteDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/RSAAttackView.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/RSAAttackView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/RSAKeyView.java
+++ b/org.jcryptool.visual.kleptography/src/org/jcryptool/visual/kleptography/ui/RSAKeyView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.library/src/org/jcryptool/visual/library/BigSquareRoot.java
+++ b/org.jcryptool.visual.library/src/org/jcryptool/visual/library/BigSquareRoot.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.library/src/org/jcryptool/visual/library/Constants.java
+++ b/org.jcryptool.visual.library/src/org/jcryptool/visual/library/Constants.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.library/src/org/jcryptool/visual/library/Lib.java
+++ b/org.jcryptool.visual.library/src/org/jcryptool/visual/library/Lib.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/MerkleHellmanPlugin.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/MerkleHellmanPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/algorithm/MerkleHellman.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/algorithm/MerkleHellman.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.merkleHellman.algorithm;
 
 import java.math.BigInteger;

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/handlers/ResetHandler.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/handlers/ResetHandler.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.merkleHellman.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/MerkleHellmanView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.merkleHellman.views;
 
 import java.math.BigInteger;

--- a/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/Messages.java
+++ b/org.jcryptool.visual.merkleHellman/src/org/jcryptool/visual/merkleHellman/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkletree/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.merkletree/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkletree/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.merkletree/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/Activator.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/Activator.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/Descriptions.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/Descriptions.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/MerkleTreeView.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/MerkleTreeView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/Address.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/Address.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/HashTreeAddress.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/HashTreeAddress.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/ISimpleMerkle.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/ISimpleMerkle.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/LTreeAddress.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/LTreeAddress.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/Node.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/Node.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/OTS.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/OTS.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/OTSHashAddress.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/OTSHashAddress.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/SimpleMerkleTree.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/SimpleMerkleTree.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/SimpleNode.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/SimpleNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/WOTSPlus.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/WOTSPlus.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/WinternitzOTS.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/WinternitzOTS.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/XMSSNode.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/XMSSNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/XMSSTree.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/algorithm/XMSSTree.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/ByteUtils.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/ByteUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/Converter.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/Converter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/MathUtils.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/files/MathUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleConst.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleConst.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeComposite.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeSignatureComposite.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeSignatureComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeVerifikationComposite.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeVerifikationComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeZestComposite.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/MerkleTreeZestComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/ZestLabelProvider.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/ZestLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/ZestNodeContentProvider.java
+++ b/org.jcryptool.visual.merkletree/src/org/jcryptool/visual/merkletree/ui/ZestNodeContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2016, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.pairingbd2/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.pairingbd2/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.pairingbd2/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/Activator.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/Activator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNCurve.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNCurve.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNCurve2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNCurve2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNField12.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNField12.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNField2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNField2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPairing.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPairing.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNParams.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNParams.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPoint.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPoint.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPoint2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/BNPoint2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/DrawUser.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/DrawUser.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ECDL.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ECDL.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/Messages.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/algorithm/BDIIBNP.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/algorithm/BDIIBNP.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/algorithm/ECBDII.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/algorithm/ECBDII.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/AuthMessage.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/AuthMessage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/DHECKeyPair.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/DHECKeyPair.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/DHECKeyPair2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/DHECKeyPair2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFP2Element.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFP2Element.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFP2toGFPPairing.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFP2toGFPPairing.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFPtoGFP2Pairing.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/GFPtoGFP2Pairing.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Logging_BNP.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Logging_BNP.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Logging_ECBDII.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Logging_ECBDII.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Messages.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PointGFP1.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PointGFP1.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PointGFP2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PointGFP2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Polynomial.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/Polynomial.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PolynomialMod.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/PolynomialMod.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/UserData_BNP.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/UserData_BNP.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/UserData_ECBDII.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/UserData_ECBDII.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/WeilGFPtoGFP2.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/basics/WeilGFPtoGFP2.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.PairingBDII.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/DefinitionAndDetails.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/DefinitionAndDetails.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/GraphPainter.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/GraphPainter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Illustration.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Illustration.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/IntroductionAndParameters.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/IntroductionAndParameters.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Logging.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Logging.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Messages.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Model.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/Model.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/View.java
+++ b/org.jcryptool.visual.pairingbd2/src/org/jcryptool/visual/PairingBDII/ui/View.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.rsa/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.rsa/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.rsa/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/Messages.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/RSAData.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/RSAData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.rsa.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/RSAComposite.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/RSAComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/RSAView.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/RSAView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/KeySelectionWizard.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/KeySelectionWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/TextEntryWizard.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/TextEntryWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/ChooseKeytypePage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/ChooseKeytypePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/DecryptSignPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/DecryptSignPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EncryptVerifyPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EncryptVerifyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterCiphertextPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterCiphertextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterPlaintextPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterPlaintextPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterSignaturePage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/EnterSignaturePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/LoadKeypairPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/LoadKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/LoadPublicKeyPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/LoadPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/NewKeypairPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/NewKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/NewPublicKeyPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/NewPublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/RsaTextModifyPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/RsaTextModifyPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SaveKeypairPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SaveKeypairPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SavePublicKeyPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SavePublicKeyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SaveWizardPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/SaveWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/TextWizardPage.java
+++ b/org.jcryptool.visual.rsa/src/org/jcryptool/visual/rsa/ui/wizards/wizardpages/TextWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/SecretSharingPlugin.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/SecretSharingPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/algorithm/Point.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/algorithm/Point.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/algorithm/ShamirsSecretSharing.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/algorithm/ShamirsSecretSharing.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/handler/HelpHandler.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/handler/HelpHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/handler/RestartHandler.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/handler/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/CoefficientDialog.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/CoefficientDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/Constants.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/Constants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/Messages.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/PrimeDialog.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/PrimeDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/SecretDialog.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/SecretDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/SecretSharingView.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/SecretSharingView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/ShamirsSecretSharingComposite.java
+++ b/org.jcryptool.visual.secretsharing/src/org/jcryptool/visual/secretsharing/views/ShamirsSecretSharingComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCAdd.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCAdd.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
@@ -8,6 +8,10 @@
  *******************************************************************************/
 // -----END DISCLAIMER-----
 package org.jcryptool.algorithm;
+
+import java.math.BigInteger;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECPoint;
 
 /**
  * This classe is used to carry out ECAdd computations.
@@ -19,12 +23,6 @@ package org.jcryptool.algorithm;
  * @since   JDK1.5.7
 
  */
-
-import java.math.BigInteger;
-import java.security.spec.ECFieldFp;
-import java.security.spec.ECPoint;
-
-
 public class ECCAdd {
 
 //  this class is used to carry out ECAddtion operation with the given parameter Point a, b and Prime field ecf

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCDouble.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCDouble.java
@@ -1,5 +1,21 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
+package org.jcryptool.algorithm;
+
+import java.math.BigInteger;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECPoint;
+
 /**
- * This class is used to compute the result after Doubling operation.
+ * This classe is used to carry out ECAdd computations.
 
  * @author  Biqiang Jiang
 
@@ -8,14 +24,6 @@
  * @since   JDK1.5.7
 
  */
-
-package org.jcryptool.algorithm;
-
-import java.math.BigInteger;
-import java.security.spec.ECFieldFp;
-import java.security.spec.ECPoint;
-
-
 public class ECCDouble {
 
 	public ECPoint eccDouble (ECPoint p, int a, ECFieldFp ecf) {

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCMultiply.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCMultiply.java
@@ -1,3 +1,18 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
+package org.jcryptool.algorithm;
+
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECPoint;
+
 /**
  * This class is used to compute the multiplication of "Double and Add" algorithm as Q = kP
 
@@ -8,12 +23,6 @@
  * @since   JDK1.5.7
 
  */
-
-package org.jcryptool.algorithm;
-
-import java.security.spec.ECFieldFp;
-import java.security.spec.ECPoint;
-
 public class ECCMultiply {
 
 	public ECPoint eccMultiply(ECPoint p, int k, int a, ECFieldFp ecf){

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCOrderAndPoints.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/ECCOrderAndPoints.java
@@ -1,3 +1,19 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
+package org.jcryptool.algorithm;
+
+import java.math.BigInteger;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECPoint;
+
 /**
  * This class is used to calculate the order of EC and points above it.
 
@@ -8,14 +24,6 @@
  * @since   JDK1.5.7
 
  */
-
-package org.jcryptool.algorithm;
-
-import java.math.BigInteger;
-import java.security.spec.ECFieldFp;
-import java.security.spec.ECPoint;
-
-
 public class ECCOrderAndPoints {
 
 

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/RandomFactorCreator.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/algorithm/RandomFactorCreator.java
@@ -1,3 +1,17 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
+package org.jcryptool.algorithm;
+
+import java.util.Random;
+
 /**
  * This class is used to create a random factor 
 
@@ -8,12 +22,6 @@
  * @since   JDK1.5.7
 
  */
-
-package org.jcryptool.algorithm;
-
-
-import java.util.Random;
-
 public class RandomFactorCreator {
 	
 	

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/DPAPlugIn.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/DPAPlugIn.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sidechannelattack;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/Constants.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/Constants.java
@@ -1,3 +1,15 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
+
+package org.jcryptool.visual.sidechannelattack.dpa.views;
+
 /**
  * This interface is used to define all Constants in Class DPAView.java.
  * 
@@ -7,9 +19,6 @@
  * 
  * @since JDK1.5.7
  */
-
-package org.jcryptool.visual.sidechannelattack.dpa.views;
-
 public interface Constants {
     String ECC_ALG_GROUP_TITLE = Messages.Constants_6;
     String ECC_ALG_TEXT = Messages.Constants_7;

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/DPAView.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/DPAView.java
@@ -1,14 +1,12 @@
-/**
- * This Class is used to create a View of DPA, which introduces the basic principle, process and
- * countermeasures of DPA attack.
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
  *
- *
- * @author Biqiang Jiang
- *
- * @version 1.0, 01/09/09
- *
- * @since JDK1.5.7
- */
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 
 package org.jcryptool.visual.sidechannelattack.dpa.views;
 

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/Messages.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/dpa/views/Messages.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sidechannelattack.dpa.views;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.sidechannelattack.dpa/src/org/jcryptool/visual/sidechannelattack/handlers/RestartHandler.java
@@ -1,14 +1,13 @@
-package org.jcryptool.visual.sidechannelattack.handlers;
-
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 // -----END DISCLAIMER-----
+package org.jcryptool.visual.sidechannelattack.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/algorithm/SquareandMultiply.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/algorithm/SquareandMultiply.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 /**
  * This Class is used to carry out Squaring and multiplication algorithm
  *

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/SPAPlugIn.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/SPAPlugIn.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.sidechannelattack.spa.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/Constants.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/Constants.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 /**
  * This interface is used to define all Constants in Class SPAView.java.
  *

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/Messages.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/Messages.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sidechannelattack.spa.views;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/SPAView.java
+++ b/org.jcryptool.visual.sidechannelattack.spa/src/org/jcryptool/visual/sidechannelattack/spa/views/SPAView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 /**
  * This Class is used to create a View of SPA, which introduces the basic principle of SPA and visualizes the process
  * and countermeasures of SPA attack.

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/Messages.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/SigPlugin.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/SigPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/Hash.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/Hash.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/Input.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/Input.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/SigGeneration.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/algorithm/SigGeneration.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureEvent.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureEvent.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureListener.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureListenerAdder.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/listener/SignatureListenerAdder.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/Messages.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/SigComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/SigComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/SigView.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/view/SigView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashWizard.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashWizardPage.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/HashWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputEditorComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputEditorComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputEditorWizardPage.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputEditorWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputFileComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputFileComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputFileWizardPage.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputFileWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputWizard.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputWizardPage.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/InputWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/Messages.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/ShowSig.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/ShowSig.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureComposite.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureWizard.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureWizardPage.java
+++ b/org.jcryptool.visual.sig/src/org/jcryptool/visual/sig/ui/wizards/SignatureWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2013, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/Messages.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/Hash.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/Hash.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sigVerification.algorithm;
 
 import java.security.MessageDigest;

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/Input.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/Input.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sigVerification.algorithm;
 
 import java.io.File;

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/SigVerification.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/algorithm/SigVerification.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sigVerification.algorithm;
 
 import java.security.PublicKey;

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/cert/CertGeneration.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/cert/CertGeneration.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/Messages.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/ModelComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/ModelComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/SigVerComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/view/SigVerComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashWizard.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/HashWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputFileWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputFileWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyEditorComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyEditorComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyEditorWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyEditorWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyFileComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyFileComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyFileWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyFileWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyWizard.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputKeyWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputWizard.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/InputWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureComposite.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureWizard.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureWizardPage.java
+++ b/org.jcryptool.visual.sigVerification/src/org/jcryptool/visual/sigVerification/ui/wizards/SignatureWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2014, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual.sphincs/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual.sphincs/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsDescriptions.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsDescriptions.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsPlugin.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsView.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/SphincsView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/algorithm/Node.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/algorithm/Node.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/algorithm/SimpleNode.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/algorithm/SimpleNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/ByteUtils.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/ByteUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/Converter.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/Converter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/MathUtils.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/files/MathUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/handlers/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsConstant.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsConstant.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsKeyGenerationView.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsKeyGenerationView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsSignVerifyView.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsSignVerifyView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsTreeView.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/SphincsTreeView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
@@ -63,7 +63,7 @@ import org.jcryptool.visual.sphincs.algorithm.aSPHINCS256;
  * @author Philipp Guggenberger
  * 
  *         TODO This class has some conceptional and visual problems. According
- *         to Hülsing the tree shown is the top XMSS tree of SPINCS. This is not
+ *         to Hï¿½lsing the tree shown is the top XMSS tree of SPINCS. This is not
  *         represented in the descriptions. Also this does not really show how
  *         this works...
  */

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/ZestLabelProvider.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/ZestLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/ZestNodeContentProvider.java
+++ b/org.jcryptool.visual.sphincs/src/org/jcryptool/visual/sphincs/ui/ZestNodeContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2018, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/EnvironmentParameters.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/EnvironmentParameters.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus;
 
 /***

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/HashFunctionType.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/HashFunctionType.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus;
 
 public enum HashFunctionType {

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/RestartCommand.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/RestartCommand.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus;
 
 import org.eclipse.core.commands.AbstractHandler;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/SphincsPlus.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/SphincsPlus.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus;
 
 import java.math.BigInteger;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/SphincsPlusPlugin.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/SphincsPlusPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/ADRS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/ADRS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.interfaces.IADRS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/ADRSTypes.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/ADRSTypes.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 /**

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/AUTH.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/AUTH.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/FORS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/FORS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.math.BigInteger;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/HashFunction.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/HashFunction.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.HashFunctionType;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Hypertree.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Hypertree.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.util.Arrays;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Key.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Key.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 public class Key {

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/MGF1.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/MGF1.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.security.MessageDigest;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SHA256.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SHA256.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.security.InvalidKeyException;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SHAKE256.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SHAKE256.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_FORS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_FORS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_HT.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_HT.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_XMSS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/SIG_XMSS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Utils.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/Utils.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.io.ByteArrayOutputStream;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/WOTSNode.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/WOTSNode.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 /***

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/WOTSplus.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/WOTSplus.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import org.jcryptool.visual.sphincsplus.EnvironmentParameters;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/XMSS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/algorithm/XMSS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.algorithm;
 
 import java.util.Stack;
@@ -27,7 +36,7 @@ public class XMSS implements IXMSS {
         int[] heights = new int[z + 1];
         byte[] node = null;
 
-        if (s % (1 << z) != 0) { // ?algo nimmt immer diesen weg, außer wenn s = 0?
+        if (s % (1 << z) != 0) { // ?algo nimmt immer diesen weg, auï¿½er wenn s = 0?
             return new byte[0];
         }
         for (int i = 0; i < numberOfLeaves; i++) {

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IADRS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IADRS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.ADRSTypes;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IFORS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IFORS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.ADRS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IHashFunction.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IHashFunction.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.ADRS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IHypertree.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IHypertree.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.SIG_HT;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/ISphincsPlus.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/ISphincsPlus.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.Key;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IWOTSplus.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IWOTSplus.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.ADRS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IXMSS.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/interfaces/IXMSS.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.interfaces;
 
 import org.jcryptool.visual.sphincsplus.algorithm.ADRS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/tests/SphincsPlusTest.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/tests/SphincsPlusTest.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.tests;
 
 //import java.io.IOException;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/Messages.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/Messages.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusForsView.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusForsView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.draw2d.ColorConstants;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusParameterView.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusParameterView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.swt.widgets.Composite;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusSignAndVerifyView.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusSignAndVerifyView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.swt.widgets.Composite;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusTreeView.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusTreeView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.draw2d.ColorConstants;

--- a/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusView.java
+++ b/org.jcryptool.visual.sphincsplus/src/org/jcryptool/visual/sphincsplus/ui/SphincsPlusView.java
@@ -1,3 +1,12 @@
+// -----BEGIN DISCLAIMER-----
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 JCrypTool Team and Contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+// -----END DISCLAIMER-----
 package org.jcryptool.visual.sphincsplus.ui;
 
 import org.eclipse.swt.SWT;

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/handler/RestartHandler.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/handler/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/Crypto.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/Crypto.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/Message.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/Message.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/ProtocolStep.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/protocol/ProtocolStep.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Arrows.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Arrows.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Attacks.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Attacks.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/CertificateShow.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/CertificateShow.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientCertificateComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientCertificateComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientChangeCipherSpecComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientChangeCipherSpecComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientFinishedComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientFinishedComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientHelloComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ClientHelloComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Messages.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerCertificateComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerCertificateComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerChangeCipherSpecComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerChangeCipherSpecComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerFinishedComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerFinishedComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerHelloComposite.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/ServerHelloComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
+++ b/org.jcryptool.visual.ssl/src/org/jcryptool/visual/ssl/views/SslView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2014, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/algorithm/VerifiableSecretSharing.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/algorithm/VerifiableSecretSharing.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/handler/RestartHandler.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/handler/RestartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/Messages.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/ReconstructionChartComposite.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/ReconstructionChartComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/VerifiableSecretSharingComposite.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/VerifiableSecretSharingComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/VerifiableSecretSharingView.java
+++ b/org.jcryptool.visual.verifiablesecretsharing/src/org/jcryptool/visual/verifiablesecretsharing/views/VerifiableSecretSharingView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/Messages.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/Messages.java
@@ -1,3 +1,13 @@
+//-----BEGIN DISCLAIMER-----
+/*******************************************************************************
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*******************************************************************************/
+//-----END DISCLAIMER-----
 package org.jcryptool.visual.wots;
 
 import org.eclipse.osgi.util.NLS;

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/OTS.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/OTS.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WOTSPlus.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WOTSPlus.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WinternitzOTS.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WinternitzOTS.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WotsView.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/WotsView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ByteUtils.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ByteUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/Converter.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/Converter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/HelpHandler.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/HelpHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/MathUtils.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/MathUtils.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ResetHandler.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ResetHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ResizeListener.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/ResizeListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/RestartHandler.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/RestartHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/WotsComposite.java
+++ b/org.jcryptool.visual.wots/src/org/jcryptool/visual/wots/files/WotsComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.visual.wots/src/wots/WOTSPlugin.java
+++ b/org.jcryptool.visual.wots/src/wots/WOTSPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2015, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ModNCalculator.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ModNCalculator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/Protocol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/Protocol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Funcs.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Funcs.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Modell.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Modell.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Primzahlen.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/Primzahlen.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSAlice.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSAlice.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSFuncs.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSFuncs.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSPerson.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/feigefiatshamir/FFSPerson.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSAlice.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSAlice.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSFuncs.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSFuncs.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSPerson.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/FSPerson.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/fiatshamir/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GAlice.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GAlice.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GBeweiser.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GBeweiser.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GFuncs.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GFuncs.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GPerson.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/GPerson.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Graph.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Graph.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Isomorphismus.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Isomorphismus.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Kante.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Kante.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Knoten.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Knoten.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/graphenisomorphie/math/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MAlice.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MAlice.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MDoor.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MDoor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MFuncs.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MFuncs.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MPerson.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/algorithm/magischetuer/MPerson.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/handlers/RestartHandler.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/handlers/RestartHandler.java
@@ -2,7 +2,7 @@ package org.jcryptool.visual.zeroknowledge.handlers;
 
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Buttons.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Buttons.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/GeneralParams.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/GeneralParams.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Generator.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Generator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Introduction.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Introduction.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/ParamsPerson.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/ParamsPerson.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimeGenerator.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimeGenerator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimeGeneratorListener.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimeGeneratorListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimePanel.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/PrimePanel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Repeat.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/Repeat.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSCombiLabel.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSCombiLabel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSFlow.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSFlow.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSParamsAliceCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSParamsAliceCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSParamsBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/FFSParamsBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/ShowVector.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/feigefiatshamir/ShowVector.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSCombiLabel.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSCombiLabel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSFlow.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSFlow.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSParamsAliceCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSParamsAliceCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSParamsBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/FSParamsBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/fiatshamir/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GCombiLabel.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GCombiLabel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GFlow.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GFlow.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GParamsAliceCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GParamsAliceCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GParamsBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/GParamsBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Line.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Line.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Point.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Point.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/ShowGraphen.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/ShowGraphen.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Zeichenflaeche.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/graphenisomorphie/Zeichenflaeche.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/Gebaeude.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/Gebaeude.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MCombiLabel.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MCombiLabel.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MFlow.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MFlow.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MParamsAliceCarol.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MParamsAliceCarol.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MParamsBob.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/MParamsBob.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/ShowGeb.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/ui/magischetuer/ShowGeb.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/FeigeFiatShamirView.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/FeigeFiatShamirView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/FiatShamirView.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/FiatShamirView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/GraphenisomorphieView.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/GraphenisomorphieView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/MagicDoorView.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/MagicDoorView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/Messages.java
+++ b/org.jcryptool.visual.zeroknowledge/src/org/jcryptool/visual/zeroknowledge/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.visual/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.visual/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.visual/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.visual/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 JCrypTool Plug-ins Team - https://github.com/jcryptool
+# Copyright (c) 2010, 2020 JCrypTool Team and Contributors - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
Changed the current year in all disclaimers from 2019 to 2020.

At the same time I have included the year of creation of the file in the copyright.

This has the advantage that the copyright is not only valid for the current year, but also for all years from the creation of the file.

The old way with only the current year looked like this:
```Copyright (c) 2020 JCrypTool Team and Contributors```

The new copyright note looks like this:
```Copyright (c) 2011, 2020 JCrypTool Team and Contributors```
